### PR TITLE
github commits autor,avatar,date can be now overriden in front-matter

### DIFF
--- a/hugo/layouts/partials/git_author.html
+++ b/hugo/layouts/partials/git_author.html
@@ -1,3 +1,6 @@
+{{ if .Params.author | and .Params.email }}
+  <a href='mailto:{{.Params.email}}'>{{.Params.author}}</a>
+{{else}}
 {{- with .File -}}
   {{- with .Path -}}
     {{- $url := print "content/" . ".json" -}}
@@ -14,4 +17,5 @@
       {{end}}
     {{- end -}}
   {{- end -}}    
+{{- end }}
 {{- end }}

--- a/hugo/layouts/partials/git_avatar.html
+++ b/hugo/layouts/partials/git_avatar.html
@@ -1,3 +1,6 @@
+{{ if .Params.avatar }}
+  {{.Params.avatar}}
+{{else}}
 {{ with .File }}
   {{ with .Path }}
     {{ $url := print "content/" . ".json" }}
@@ -10,4 +13,5 @@
       {{ end }}
     {{ end }}
   {{ end }}
+{{ end }}
 {{ end }}

--- a/hugo/layouts/partials/git_date.html
+++ b/hugo/layouts/partials/git_date.html
@@ -1,3 +1,7 @@
+{{ if .Params.publishdate }}
+  <span id="0"></span>
+  <script>$("#0").html(moment("{{- .Params.publishdate -}}").fromNow())</script>
+{{else}}
 {{ with .File }}
   {{ with .Path }}
     {{ $url := print "content/" . ".json"}}
@@ -12,4 +16,5 @@
       {{ end }}
     {{ end }}
   {{ end }}
+{{ end }}
 {{ end }}


### PR DESCRIPTION
The website build uses git commits info to set author, avatar and publish date e.g. in blogs or tutorials automatically. This change adds the ability to override this mechanism with corresponding front-matte properties: `author`, `avatar` and `publishdate`. If any of these is specified it takes priority over the commits info.