### PR TITLE
based on cc-jobimage,switched to semver

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -79,6 +79,7 @@ fi
 echo  ;
 echo "Running pre-site-building tasks" ;
 npm install
+npm prune --production
 export CONTENT=$generator/hugo/content
 node ./node/index.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gardener-project/cc/job-image:1.564.0 as base
+FROM  alpine:3.11 as base
 
 RUN apk add curl
 
@@ -12,11 +12,13 @@ RUN curl -fsSLO --compressed https://github.com/gohugoio/hugo/releases/download/
     && mkdir -p /usr/local/bin \
     && mv ./hugo /usr/local/bin/hugo 
 
-FROM eu.gcr.io/gardener-project/cpet/node-image:1.0.0
+FROM eu.gcr.io/gardener-project/cc/job-image:1.564.0
 
 COPY --from=base /usr/local/bin/hugo /usr/local/bin/hugo
 
-RUN apk add --update bash asciidoctor libc6-compat libstdc++
+RUN apk add --update bash asciidoctor libc6-compat libstdc++ nodejs npm \
+    && addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/bash -D node
 
 VOLUME /src
 VOLUME /output

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,16 @@ setup:
 .PHONY: build
 build:
 	@.ci/build
-# `make image-build` builds a new docker image. Use thee $TAG environment variable to specify the image tag. 
-# Example: `$ make image-build TAG=v10`
+# `make image-build` builds a new docker image. Use thee $TAG environment variable to specify the image tag.
+# The tag `latest` is automatically assigned in addition.
+# Example: `$ make image-build TAG=10.0.0`
 .PHONY: image-build
 image-build:
 	@scripts/image-build
 # `make image-push` pushes a local image to the project GCR repository. An installed and authenticated gcloud tool 
-# is required to perform the operation. The image to push is identified by its tag.
-# Example: `$ make image-push TAG=v10`
+# is required to perform the operation. The image to push is identified by its tag. Use semver for tags. Tag `latest`
+# is automatically assigned in addition.
+# Example: `$ make image-push TAG=10.0.0`
 .PHONY: image-push
 image-push:
 	@scripts/image-push

--- a/scripts/image-build
+++ b/scripts/image-build
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
 
 # GCR coordinates
 HOST=eu.gcr.io

--- a/scripts/image-push
+++ b/scripts/image-push
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 HOST=eu.gcr.io
 PROJECT=gardener-project


### PR DESCRIPTION
**What this PR does / why we need it**:
The build now requires `gardener-ci`, which is part of the cc/job-image so we use it as basis and node/npm are added now as alpine package dependency. An unfortunate side effect is that the image size grew significantly up to 850MB. Future improvement steps would be to move to alpine as basis and copy only the minimal dependencies from cc/job-image.