### PR TITLE
moved git info to hugo/data

### DIFF
--- a/hugo/assets/sass/_blog.scss
+++ b/hugo/assets/sass/_blog.scss
@@ -4,19 +4,35 @@
 // }
 
 .blogs {
-  .author {
-    display: block;
-    font-size: 1.3rem;
-    text-align: center;
-    line-height: 1;
-    margin: 10px 0 5px;
+  .authors {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    .author {
+      display: flex;
+      flex-flow: column;
+      font-size: 1.3rem;
+      text-align: center;
+      line-height: 1.5;
+    }
+    li.author {
+      margin: 5px;
+    }
+  }
+  ul.authors {
+    margin: 0px;
+    padding-left: 0px !important;
   }
   .publishdate {
     display: block;
     font-size: 1.3rem;
     text-align: center;
     line-height: 1;
-  }
+    margin-top: 5px;
+    color: #555;
+    font-family: $font-family-light;
+  } 
   .share-ribbon {
     display: flex;
     button.btn {

--- a/hugo/layouts/blog/list.html
+++ b/hugo/layouts/blog/list.html
@@ -9,22 +9,7 @@
     <article class="post row" data-path="">
         <div class="wrapper">
             <div class="two columns">
-                {{$avatar := (trim ( trim (partial "git_avatar.html" .) " \r\n") " ") }}
-                {{$author := (trim (trim (partial "git_author.html" .) " \r\n") " ") }}
-                {{$publishdate := (trim (trim (partial "git_date.html" .) " \r\n") " ")}}
-                {{if gt (len $avatar) 0}}
-                <img {{ printf "src=%q" $avatar | safeHTMLAttr }}
-                    class="user-icon icons"
-                    alt="blog author avatar">
-                {{else}}
-                    <div style="width:10px;height:10px;"></div>
-                {{end}}
-                {{if gt (len $author) 0}}
-                <span class="author">{{$author | safeHTML}}</span>
-                {{end}}
-                {{if gt (len $publishdate) 0}}
-                <span class="publishdate">{{$publishdate | safeHTML}}</span>
-                {{end}}
+                {{partial "blog-authors" .}}
             </div>
             <div class="ten columns">
                 <h2>{{ .Title }}<a href="{{$page.URL | relURL}}" class="title-link clipboard-copy"><i class="fa fa-link"></i></a></h2>

--- a/hugo/layouts/blog/single.html
+++ b/hugo/layouts/blog/single.html
@@ -11,22 +11,7 @@
       <article class="post row" data-path="">
         <div class="wrapper">
             <div class="two columns">
-                {{$avatar := (trim ( trim (partial "git_avatar.html" .) " \r\n") " ") }}
-                {{$author := (trim (trim (partial "git_author.html" .) " \r\n") " ") }}
-                {{$publishdate := (trim (trim (partial "git_date.html" .) " \r\n") " ")}}
-                {{if gt (len $avatar) 0}}
-                <img {{ printf "src=%q" $avatar | safeHTMLAttr }}
-                    class="user-icon icons"
-                    alt="blog author avatar">
-                {{else}}
-                    <div style="width:10px;height:10px;"></div>
-                {{end}}
-                {{if gt (len $author) 0}}
-                <span class="author">{{$author | safeHTML}}</span>
-                {{end}}
-                {{if gt (len $publishdate) 0}}
-                <span class="publishdate">{{$publishdate | safeHTML}}</span>
-                {{end}}
+              {{partial "blog-authors" .}}
             </div>
             <div class="ten columns">
                 <h2>{{ .Title }}<a href="{{.URL | relURL}}" class="title-link clipboard-copy"><i class="fa fa-link"></i></a></h2>

--- a/hugo/layouts/partials/blog-authors.html
+++ b/hugo/layouts/partials/blog-authors.html
@@ -1,0 +1,57 @@
+{{ $publishdate:= .Params.publishdate }}
+{{ with $publishdate }}
+  {{ $publishdate = (print (.Format "2006-01-02")) }}
+{{else}}
+{{ with .File }}
+  {{ with .Path }}
+    {{ $url := print "/data/" . ".json"}}
+    {{ if (fileExists $url) -}}
+      {{ $publishdate = (getJSON $url).publishdate }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ end }}
+<ul class="authors">
+{{ with .Params.authors }}
+    {{ range . }}
+    {{- template "author" dict "name" .name "email" .email "avatar" .avatar -}}
+    {{ end }}
+{{else}}
+{{- with .File -}}
+  {{- with .Path -}}
+    {{- $url := print "/data/" . ".json" -}}
+    {{- if (fileExists $url) -}}
+      {{- $data := (getJSON $url) -}}
+      {{ with $data.author }}
+      {{- template "author" dict "name" .name "email" .email "avatar" .avatar_url -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end }}
+{{- end }}
+</ul>
+{{with $publishdate }}
+<span class="publishdate" data-publishdate="{{ . | safeHTMLAttr }}">{{. | safeHTML}}</span>
+{{end}}
+
+{{- define "author" -}}
+{{- $name := .name -}}
+{{- $email := .email -}}
+{{- $avatar := .avatar -}}
+{{- $publishdate := .publishdate -}}
+
+<li class="author">
+{{with $avatar}}
+{{with $email }}<a href="mailto:{{$email | safeHTMLAttr }}">{{end}}
+<img {{ printf "src=%q" . | safeHTMLAttr }}
+    class="user-icon icons"
+    alt="blog author avatar">
+{{else}}
+    <div style="width:10px;height:10px;"></div>
+{{end}}
+{{with $name }}
+<span class="name">{{ $name | safeHTML}}</span>
+{{with $email }}</a>{{end}}
+{{end}}
+</li>
+{{- end -}}

--- a/hugo/layouts/partials/git_author.html
+++ b/hugo/layouts/partials/git_author.html
@@ -3,19 +3,20 @@
 {{else}}
 {{- with .File -}}
   {{- with .Path -}}
-    {{- $url := print "content/" . ".json" -}}
+    {{- $url := print "/data/" . ".json" -}}
     {{- if (fileExists $url) -}}
       {{- $scratch := newScratch -}}
-      {{- range (getJSON $url) -}}
-        {{- if (hasPrefix .commit.message "[int]") -}}
-        {{- else -}}
-        {{- $scratch.SetInMap "authors" (print .commit.author.email) (printf "<a href='mailto:%s'>%s</a>" .commit.author.email .commit.author.name) -}}
-        {{- end -}}
-      {{- end -}}
-      {{ with ($scratch.GetSortedMapValues "authors") }}
-      {{- delimit . "," -}}
+      {{- $data := (getJSON $url) -}}
+      {{ with $data.author }}
+      {{- $scratch.Add "authors" (slice (printf "<a href='mailto:%s'>%s</a>" .email .name)) -}}
       {{end}}
+      {{- range $data.contributors -}}
+      {{- $scratch.Add  "authors" (slice (printf "<a href='mailto:%s'>%s</a>" .email .name)) -}}
+      {{end}}
+      {{- with ($scratch.Get "authors") -}}
+      {{- delimit .  "," -}}
+      {{- end -}}
     {{- end -}}
-  {{- end -}}    
+  {{- end -}}
 {{- end }}
 {{- end }}

--- a/hugo/layouts/partials/git_avatar.html
+++ b/hugo/layouts/partials/git_avatar.html
@@ -3,14 +3,9 @@
 {{else}}
 {{ with .File }}
   {{ with .Path }}
-    {{ $url := print "content/" . ".json" }}
+    {{ $url := print "/data/" . ".json" }}
     {{ if (fileExists $url) -}}
-      {{range  (last 1 (getJSON $url)) }}
-      {{- if (hasPrefix .commit.message "[int]") -}}
-      {{- else -}}
-        {{.author.avatar_url}}
-      {{ end }}
-      {{ end }}
+        {{(getJSON $url).author.avatar_url}}
     {{ end }}
   {{ end }}
 {{ end }}

--- a/hugo/layouts/partials/git_date.html
+++ b/hugo/layouts/partials/git_date.html
@@ -1,19 +1,11 @@
-{{ if .Params.publishdate }}
+{{ with .Params.publishdate }}
   <span data-publishdate="{{- .PublishDate.Format "2006-01-02" -}}"></span>
 {{else}}
 {{ with .File }}
   {{ with .Path }}
-    {{ $url := print "content/" . ".json"}}
+    {{ $url := print "/data/" . ".json"}}
     {{ if (fileExists $url) -}}
-      {{ $id := md5 $url}}
-      {{ $break := false}}
-      {{range (getJSON $url) }}
-      {{- if or ($break)  (hasPrefix .commit.message "[int]")  -}}
-      {{- else -}}
-        {{ $break = true }}
-        <span data-publishdate="{{- .commit.author.date -}}"></span>
-      {{ end }}
-      {{ end }}
+      <span data-publishdate="{{- (getJSON $url).publishdate -}}"></span>
     {{ end }}
   {{ end }}
 {{ end }}

--- a/hugo/layouts/partials/tail-scripts.html
+++ b/hugo/layouts/partials/tail-scripts.html
@@ -33,7 +33,7 @@
         inlineSVG.init();
 
         $("[data-publishdate]").each(function(){
-          $(this).text(moment($(this, "YYYY-MM-DD").attr("data-publishdate")).fromNow());
+          $(this).text(moment($(this, "YYYY-MM-DD", "YYYY-MM-DD hh:mm:ss").attr("data-publishdate")).fromNow());
         });
           
         new ClipboardJS('.clipboard-copy');

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,6 +451,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "moment": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "axios": "0.19.2",
     "fetch": "1.1.0",
     "front-matter": "3.1.0",
     "glob": "7.1.6",
     "is-relative-url": "3.0.0",
+    "moment": "^2.26.0",
     "shuffle-array": "^1.0.1",
     "sync-request": "6.1.0",
-    "url-exists": "1.0.3",
-    "axios": "0.19.2"
+    "url-exists": "1.0.3"
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Tailored git info supporting site building in layouts that need authors, contributors and their details (names, avatars,emails), lastmodified/publish dates. Previously, it was serialized as raw commits history per file in the content repository (/documentation) and was unnecessarily served online along the actual site content. Now git info is serialized in the hugo/data folder, which is meant by hugo precisely for this purpose and is not exposed as site content too. As the git info is tailored specifically for our use case now, the layouts using it now require less transformations to make use of it too.

Blogs now support multiple authors too.

The partials working with gitinfo first check the page for 
```yaml
authors:
- name: ""
   email: ""
   avatar: ""
publishdate: YYYY-MM-DD
```
and use either authors or publishdate if they find one. Otherwise, they fallback to the gitinfo and fetch the author (can be only one  in this case) and the publishdate form there.

Why we don't use the built-in support for gitinfo in hugo? It is too limited (.e.g. no avatars) and it doesn't work with symlinks as in our website repository topology.
