### PR TITLE
News and blogs

### DIFF
--- a/hugo/assets/sass/_base.scss
+++ b/hugo/assets/sass/_base.scss
@@ -389,7 +389,54 @@ samp {
 //   font-size: 2rem;
 //   color: #555;
 // }
-
+.share-ribbon {
+  display: flex;
+  button.btn {
+    height: 20px;
+    padding: 1px 8px 1px !important;
+    color: $color-highlight !important;
+    border-radius: 3px !important;
+    box-shadow: 0px 2px 4px 1px rgba(0, 0, 0, 0.2) !important;
+  }
+  button.btn:active {
+    background-color: $color-highlight !important;
+    color: #fff !important;
+    box-shadow: none;
+    transform: scale(0.99);
+  }
+}
+.share-ribbon > * {
+  margin-right: 10px;
+}
+#body-inner {
+  a.nav-link {
+    font-family: $font-family-regular;
+    line-height: 1 !important;
+    font-size: 90%;
+    margin: 1rem 0 3rem;
+    padding: 1rem;
+    color: $color-highlight;
+    border: 1px solid #d5755d4d;
+    display: inline-block;
+    &:hover {
+      text-decoration: none;
+      color: #fff;
+      background-color: $color-highlight;
+      border-color: #d5755d;
+    }
+    &.back {
+      &:before {
+        content: "\f104";
+        display: inline-block;
+        margin-right: 5px;
+        font: normal normal normal 14px/1 FontAwesome;
+        font-size: inherit;
+        text-rendering: auto;
+        -webkit-font-smoothing: antialiased
+      }
+    }
+  }
+}
 .howto_tickets {
   display: flex;
   align-items: center;

--- a/hugo/assets/sass/_blog.scss
+++ b/hugo/assets/sass/_blog.scss
@@ -33,25 +33,6 @@
     color: #555;
     font-family: $font-family-light;
   } 
-  .share-ribbon {
-    display: flex;
-    button.btn {
-      height: 20px;
-      padding: 1px 8px 1px !important;
-      color: $color-highlight !important;
-      border-radius: 3px !important;
-      box-shadow: 0px 2px 4px 1px rgba(0, 0, 0, 0.2) !important;
-    }
-    button.btn:active {
-      background-color: $color-highlight !important;
-      color: #fff !important;
-      box-shadow: none;
-      transform: scale(0.99);
-    }
-  }
-  .share-ribbon > * {
-    margin-right: 10px;
-  }
   a.title-link {
     color: #b6b6b6;
     text-decoration: none;

--- a/hugo/assets/sass/_news-feed.scss
+++ b/hugo/assets/sass/_news-feed.scss
@@ -52,7 +52,6 @@
   }
   .news-box {
     display: flex;
-    height: 3.5rem;
     /* border-left: 4px solid #e8e8e8; */
     margin: 0 0 0 5px;
     cursor: pointer;
@@ -63,7 +62,6 @@
       text-decoration: none;
       display: flex;
       flex-flow: column;
-      justify-content: center;
       * {
         text-decoration: none;
       }

--- a/hugo/assets/sass/_news.scss
+++ b/hugo/assets/sass/_news.scss
@@ -1,4 +1,20 @@
 #body-inner {
+  a.nav-link {
+    font-family: $font-family-regular;
+    line-height: 1 !important;
+    font-size: 90%;
+    margin: 1rem 0 3rem;
+    padding: 1rem;
+    color: $color-highlight;
+    border: 1px solid #d5755d4d;
+    display: inline-block;
+    &:hover {
+      text-decoration: none;
+      color: #fff;
+      background-color: $color-highlight;
+      border-color: #d5755d;
+    }
+  }
   .page {
     .page-title {
       display: block;
@@ -13,14 +29,18 @@
     }
     &.news-feed {
       .news-feed {
+        display: grid;
+        overflow: hidden;
+        grid-template-columns: repeat(1, 1fr);
+        grid-auto-rows: 1fr;
+        grid-row-gap: 20px;
         margin: 4rem 0 0;
         padding-left: 0;
         .news-item {
           a.nav-link {
-            margin: 2rem 0;
-            padding: 0 1rem;
-            width: 100%;
             display: flex;
+            width: 100%;
+            margin: 0;
             flex-flow: column;
             font-family: $font-family-medium;
             font-size: 1.6rem;
@@ -32,16 +52,15 @@
               color: $color-highlight;
             }
             h4 {
-              margin: 1rem 0 0.5rem;
+              margin: 0.5rem 0 0.5rem;
               font-family: $font-family-regular;
-              color: #0b8062 !important;
+              // color: #0b8062 !important;
               .arrow-right {
                 color: $color-highlight;
               }
             }
-            .eventdate {
-              font-family: $font-family-light;
-              display: block;
+            h5 {
+              margin: -0.5rem 0 0.5rem;
             }
             .publish-date {
               font-family: $font-family-regular;
@@ -54,7 +73,7 @@
         }
       }
       ul.news-feed li {
-        margin-left: 0 !important;
+        margin-bottom: 0;
         list-style: none;
       }
     }
@@ -73,22 +92,6 @@
     //     border-color: $color-highlight;
     //   }
     // }
-    +a.nav-link {
-      font-family: $font-family-regular;
-      line-height: 1 !important;
-      font-size: 90%;
-      margin: 1rem 0 3rem;
-      padding: 1rem;
-      color: $color-highlight;
-      border: 1px solid #d5755d4d;
-      display: inline-block;
-      &:hover {
-        text-decoration: none;
-        color: #fff;
-        background-color: $color-highlight;
-        border-color: #d5755d;
-      }
-    }
   }
 }
 

--- a/hugo/assets/sass/_news.scss
+++ b/hugo/assets/sass/_news.scss
@@ -1,20 +1,4 @@
 #body-inner {
-  a.nav-link {
-    font-family: $font-family-regular;
-    line-height: 1 !important;
-    font-size: 90%;
-    margin: 1rem 0 3rem;
-    padding: 1rem;
-    color: $color-highlight;
-    border: 1px solid #d5755d4d;
-    display: inline-block;
-    &:hover {
-      text-decoration: none;
-      color: #fff;
-      background-color: $color-highlight;
-      border-color: #d5755d;
-    }
-  }
   .page {
     .page-title {
       display: block;

--- a/hugo/layouts/blog/blog-list.html
+++ b/hugo/layouts/blog/blog-list.html
@@ -4,6 +4,9 @@
     <!-- Ranges through content/blog/*.md -->
     {{ with .Site.GetPage "blog" }}
     {{ range $index, $page :=  sort (where (where .Site.Pages "Type" "in" (slice "blog" "Blog")) "Params.aggregate" "!=" true) ".Params.publishdate" "desc"}}
+    {{if $page.Params.publishdate}}
+      {{$publishTime := time $page.Params.publishdate}}
+      {{if $publishTime.Before now}}
     <article class="post row" data-path="">
       <div class="wrapper">
           <div class="two columns">
@@ -17,11 +20,13 @@
                 <!--button class="btn copy-url clipboard-copy" data-clipboard-text="{{$page.URL | absURL}}" href="{{$page.URL | absURL}}"><i class="fa fa-copy"></i></button-->
               </div>
               <p>
-                  {{.Content}}
+                {{.Content}}
               </p>
           </div>
       </div>
     </article>
+      {{end}}
+    {{end}}
     {{end}}
     {{end}}
   </div>

--- a/hugo/layouts/blog/list.html
+++ b/hugo/layouts/blog/list.html
@@ -1,7 +1,7 @@
 {{ define "page-content"}}
   <script src="/js/moment.js"></script>
   <div class="blogs page">
-      <a href="{{ "blog" | relURL}}" class="nav-link"><span class="icon-arrow-left"></span> Back to Blogs</a>
+      <a href="{{ "blog" | relURL}}" class="nav-link back">Back to Blogs</a>
       <article class="post row" data-path="">
         <div class="wrapper">
             <div class="two columns">
@@ -20,7 +20,7 @@
             </div>
         </div>
       </article>
-      <a href="{{ "blog" | relURL}}" class="nav-link"><span class="icon-arrow-left"></span> Back to Blogs</a>
+      <a href="{{ "blog" | relURL}}" class="nav-link back">Back to Blogs</a>
   </div>
 {{ end }}
 

--- a/hugo/layouts/news/list.html
+++ b/hugo/layouts/news/list.html
@@ -15,7 +15,7 @@
               <span class="publish-date">{{ .Format "Monday, Jan 2, 2006" }}</span>
               {{end}}          
               <h4>{{ .Title }} <span class="arrow-right">&rarr;</span></h4>
-              <span class="eventdate">{{ .Params.eventdate }}</span>
+              <h5>{{ .Params.newsSubtitle }}</h5>
             </a>
           </li>
           {{end}}

--- a/hugo/layouts/news/single.html
+++ b/hugo/layouts/news/single.html
@@ -3,9 +3,16 @@
   <a href="#" class="tool-btn copy" data-clipboard-text="{{.URL | relURL}}" title="Copy the link to this news"><span class="fa fa-clone"></span></a-->
 {{ end }}
 {{ define "page-content" }}
-  <a href="{{ "news" | relURL}}" class="nav-link"><span class="icon-arrow-left"></span> Back to news</a>
   <div class="page">
+    <div class="top-bar">
+      <a href="{{ "news" | relURL}}" class="nav-link back">Back to news</a>
+    </div>
     {{ .Content }}
+    <div class="share-ribbon">
+      <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="{{ .Title }}" data-url="{{.URL | absURL}}" data-hashtags="GardenerProject" data-dnt="true" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+      <script type="IN/Share" data-url="{{.Permalink}}"></script>
+      <!--button class="btn copy-url clipboard-copy" data-clipboard-text="{{.URL | absURL}}" href="{{.URL | absURL}}"><i class="fa fa-copy"></i></button-->
+    </div>
   </div>
   <!-- <a href="{{ "news" | relURL}}" class="nav-link"><span class="icon-arrow-left"></span> Back to news</a> -->
 {{ end }}

--- a/hugo/layouts/news/single.html
+++ b/hugo/layouts/news/single.html
@@ -3,13 +3,11 @@
   <a href="#" class="tool-btn copy" data-clipboard-text="{{.URL | relURL}}" title="Copy the link to this news"><span class="fa fa-clone"></span></a-->
 {{ end }}
 {{ define "page-content" }}
-  {{ $options := (dict "targetPath" "css/gardener.css" "outputStyle" "compressed" "enableSourceMap" true ) }}
-  {{ $style := resources.Get "sass/gardener.scss" | resources.ToCSS $options | resources.Fingerprint }}
-  <link rel="stylesheet" href="{{ $style.RelPermalink }}">
+  <a href="{{ "news" | relURL}}" class="nav-link"><span class="icon-arrow-left"></span> Back to news</a>
   <div class="page">
     {{ .Content }}
   </div>
-  <a href="{{ "news" | relURL}}" class="nav-link"><span class="icon-arrow-left"></span> Back to news</a>
+  <!-- <a href="{{ "news" | relURL}}" class="nav-link"><span class="icon-arrow-left"></span> Back to news</a> -->
 {{ end }}
 {{define "tails-scripts-custom" }}
 <!--

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -13,11 +13,14 @@
       {{- with .Site.GetPage "section" "news" -}}
       <li><a href="{{ .URL }}">{{.Title}}</a></li>
       {{- end -}}
-      {{- with .Site.GetPage "section" "documentation" -}}
-      <li><a href="{{ .URL }}">Documentation</a></li>
-      {{- end -}}
       {{- with .Site.GetPage "section" "community" -}}
       <li><a href="{{ .URL }}">{{.Title}}</a></li>
+      {{- end -}}
+      {{- with .Site.GetPage "section" "adopter" -}}
+      <li><a href="{{ .URL }}">{{.Title}}</a></li>
+      {{- end -}}
+      {{- with .Site.GetPage "section" "documentation" -}}
+      <li><a href="{{ .URL }}">Documentation</a></li>
       {{- end -}}
     </ul>
     <img src="{{"images/lp/gardener-logo.svg" | relURL}}" alt="Logo Gardener" class="logo"/>

--- a/hugo/layouts/partials/news.html
+++ b/hugo/layouts/partials/news.html
@@ -1,20 +1,31 @@
 <ul class="news-feed">
-{{ range $index, $page :=  (where $.Site.Pages "Type" "news") }}
+{{ range $index, $page :=  (where $.Site.Pages "Type" "in" "news blogs") }}
   {{$isExpired:= false}}
   {{with $page.Params.archivedate}}
-  {{$exp := time $page.Params.archivedate}}
-  {{$isExpired = $exp.Before now}}
+    {{$exp := time $page.Params.archivedate}}
+    {{$isExpired = $exp.Before now}}
   {{end}}
-  {{if or $isExpired (eq $page.Params.aggregate true) }}
+  {{$isNotPublishTime:= false}}
+  {{with $page.Params.publishdate}}
+    {{$d := time $page.Params.publishdate}}
+    {{$isNotPublishTime = $d.After now}}
+  {{end}}
+  {{if or $isExpired $isNotPublishTime (eq $page.Params.aggregate true) }}
   {{else}}
+    {{$isNewsBox := false}}
+    {{if eq $page.Type "news"}}
+      {{$isNewsBox = true}}
+    {{end}}
   <li class="news-box">
-    <a href="#{{$index}}" data-lity>
+    <a href="{{ if $isNewsBox }}#{{$index}}" data-lity{{else}}{{$page.RelPermalink}}"{{end}}>
       <div class="feed-heading">
-        <span class="name">{{$page.Title}}</span>
+        <span class="name">{{or $page.LinkTitle $page.Title}}</span>
         <span class="event-date">{{$page.Params.eventdate}}</span>
       </div>
     </a>
+    {{ if $isNewsBox }}
     <div class="content lity-hide" id="{{$index}}"><div data-url="{{$page.URL | absURL}}">{{$page.Content}}</div></div>
+    {{ end }}
   </li>
   {{end}}
 {{end}}

--- a/hugo/layouts/partials/news.html
+++ b/hugo/layouts/partials/news.html
@@ -1,5 +1,5 @@
 <ul class="news-feed">
-{{ range $index, $page :=  (where $.Site.Pages "Type" "in" "news blogs") }}
+{{ range $index, $page := sort (where $.Site.Pages "Type" "in" "news blogs") ".Params.publishdate" }}
   {{$isExpired:= false}}
   {{with $page.Params.archivedate}}
     {{$exp := time $page.Params.archivedate}}

--- a/hugo/layouts/partials/news.html
+++ b/hugo/layouts/partials/news.html
@@ -20,7 +20,7 @@
     <a href="{{ if $isNewsBox }}#{{$index}}" data-lity{{else}}{{$page.RelPermalink}}"{{end}}>
       <div class="feed-heading">
         <span class="name">{{or $page.LinkTitle $page.Title}}</span>
-        <span class="event-date">{{$page.Params.eventdate}}</span>
+        <span class="event-date">{{$page.Params.newsSubtitle}}</span>
       </div>
     </a>
     {{ if $isNewsBox }}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the following improvements are introduced:
- The news feed on the landing page now includes also blogs. Blog news feed items that appear there are links directly to the respective blog in the Blogs section. You no longer need to publish a separate _News_ content to announce a blog on the news feed.
- News are preserved as distinct content type, but will be largely used for _inline_ short notices for now on. Such notices will appear in a lightbox container as up to now. They will continue to be available for exploration in the news section.
- Scheduling of news now includes also publish date, i.e. if there is a `publishdate` property in the front-matter, it will be considered when deciding whether to show this news item in the feed on the landing page. The `archivedate` continues to serve as end of life in the news feed on the landing page after which the news item is going to be exploarable only in the News section.
- Scheduling now spans over blogs too and is again controlled by `publishdate` and `archivedate`. The `publishdate` concerns both the landing page news feed and the blogs section. A blog scheduled to be published in a future date will not appear in either until that date. The `archivedate` concerns only the news feed. After that date (if specified), the item will no longer appear in the feed.
Both properties are in format `YYYY-MM-DD`.
- The `publishdate` front-matter property is now mandatory both for news and blogs.
- The news feed now considers the `linkTitle` standard front-matter property with priority if specified. It's intended as a short news title that can accommodate in the limited feed space 
-  The new 'newsSubtitle' property replaces `eventdate' and is used by the news feed as a short subtitle if specified.
- The news now also feature share buttons for social media similar to blogs
- The 'Back To ..' `nav-link` buttons now start with a left arrow

