### PR TITLE
News type

### DIFF
--- a/hugo/assets/sass/_news-item.scss
+++ b/hugo/assets/sass/_news-item.scss
@@ -1,0 +1,63 @@
+.news-item {
+  font-family: var(--font-family-book);
+  blockquote {
+    padding: 1rem 1.5rem !important;
+    background: #f5f5f5 !important;
+    margin-inline-start: 1rem;
+    margin-inline-end: 1rem;
+    @media (min-width: 750px) {
+      padding: 1rem 2rem !important;
+      margin-inline-start: 4rem;
+      margin-inline-end: 4rem;
+    }
+    &::before {
+      display: none;
+      p {
+        margin-bottom: 0;
+      }
+    }
+  }
+  img {
+    display: block;
+    width: 100%;
+    height: auto;
+    margin: 0rem auto 2.5rem;
+    @media (min-width: 750px) {
+      width: 75%;
+    }
+    @media (min-width: 1000px) {
+      width: 50%;
+    }
+  }
+}
+@mixin news-lity-title {
+  margin: -3rem -3rem 3rem;
+  padding: 3rem 3rem 0;
+  color: #fff;
+  background-color: #0b8062;
+}
+@mixin news-lity-subtitle {
+  margin-left: -3rem;
+  margin-right: -3rem;
+  margin-top: -3rem;
+  padding: 0.5rem 3rem;
+  background: #e1e1e1;
+}
+.lity-content {
+  .content {
+    .news-item {
+      h1:first-child {
+        @include news-lity-title;
+        & + h3 {
+          @include news-lity-subtitle;
+        }
+      }
+      h2:first-child {
+        @include news-lity-title;
+        & + h4 {
+          @include news-lity-subtitle;
+        }
+      }
+    }
+  }
+}

--- a/hugo/assets/sass/_news-releasenotes.scss
+++ b/hugo/assets/sass/_news-releasenotes.scss
@@ -1,7 +1,6 @@
 .release-notes {
   background-color: #fff;
   word-break: break-word;
-  padding: 4rem 3rem;
   font-family: $font-family-light;
   h1 {
     font-size: 4rem;

--- a/hugo/assets/sass/_news.scss
+++ b/hugo/assets/sass/_news.scss
@@ -1,5 +1,6 @@
 #body-inner {
   .page {
+    padding-bottom: 4rem;
     .page-title {
       display: block;
       background: none;
@@ -80,5 +81,6 @@
 }
 
 @import "news-feed";
+@import "news-item";
 @import "news-meetup";
 @import "news-releasenotes";

--- a/hugo/layouts/partials/news.html
+++ b/hugo/layouts/partials/news.html
@@ -24,7 +24,7 @@
       </div>
     </a>
     {{ if $isNewsBox }}
-    <div class="content lity-hide" id="{{$index}}"><div data-url="{{$page.URL | absURL}}">{{$page.Content}}</div></div>
+    <div class="content lity-hide" id="{{$index}}"><div data-url="{{$page.URL | absURL}}" class="{{or $page.Params.newsType "news-item"}}">{{$page.Content}}</div></div>
     {{ end }}
   </li>
   {{end}}
@@ -46,11 +46,12 @@
     display: flex;
     overflow-y: auto;
     min-height: 25vh;
+    background-color: #fff;
   }
   .lity-content .content [data-url] {
     flex: 1 0 100%;
-    background: #fff;
-    padding: 1.5rem;
+    height: 100%;
+    padding: 3rem 3rem 4rem;
   }
   .lity-tools {
     display: block;


### PR DESCRIPTION
**What this PR does / why we need it**:
The news layouts in the News section and those in the landing page light box are different. Actually, there are no hugo layouts controlling the the light box news items. Their content is inline on the landing page and therefore it is imperative that its styles are scoped properly or they mes sup the whole landing page. On the other hand especially for news it's often the case that some specify styles are needed inline. 
The roadmap is to have several standard styles for the recurring news types and require that any other are scoped in a div with item-specific class and all styles are namespaced with it.
This PR removes this requirement for the 'standard' news types. All that's necessary now is to provide a 'newsType: <class-name>' front-matter property. The class ends up as entry in the lightbox container classes list. if none is specified it defaults to `news-item'. Currently, we have standardized styles for `news-item` (generic), `release-notes` (for release notes) and `meetups` (for meetup announcements). The necessity to maintain release notes as a standard style type will be evaluated as next step and eventually it may drop out.
