### PR TITLE
Blogs home page

### DIFF
--- a/hugo/assets/sass/_blog-home.scss
+++ b/hugo/assets/sass/_blog-home.scss
@@ -1,0 +1,356 @@
+.blogs {
+  &.home {
+    display: flex;
+    .list {
+      flex: 1 0 100%;
+      @media (min-width: 1000px) {
+        flex: 1 0 70%;
+      }
+      .topbar {
+        display: block;
+        margin-top: -5rem;
+        @media (min-width: 750px) {
+          margin-top: 0;
+        }
+        svg {
+          &.icon {
+            vertical-align: middle;
+            fill: currentColor;
+            width: 24px;
+            height: 24px;
+            --outline-color: #555;
+            fill: #555;
+            &.sort {
+              width: 23px;
+              height: 1em;
+            }
+          }
+        }
+        .menu-toggler {
+          display: block;
+          font-size: 3rem;
+          border-radius: 50%;
+          margin: 1rem 0 2rem auto;
+          width: 30px;
+          text-align: center;
+          @media (min-width: 750px) {
+            margin: 0 0 0 1rem;
+            order: 3;
+          }
+          @media (min-width: 1000px) {
+            display: none;
+          }
+        }
+        &.controls {
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: flex-end;
+          padding-bottom: 10px;
+          border-bottom: 1px solid #555;
+          @media (min-width: 1000px) {
+            justify-content: space-between;
+          }
+          //background-color: #fbfbfb;
+          .nav-link {
+            margin: 0 0 0.85rem 2rem !important;
+          }
+          .controls-collapse {
+            &.toggle {
+              display: inline-block;
+              margin-left: 10px;
+              &:not(.active) {
+                .icon {
+                  &.filter {
+                    --outline-color: #888;
+                    fill: #fff;
+                  }
+                }
+                &:hover {
+                  .icon {
+                    --outline-color: $color-highlight;
+                  }
+                }
+              }
+              &.active {
+                .icon {
+                  &.filter {
+                    --outline-color: var(--color-emphasis);
+                    fill: #fff;
+                  }
+                }
+              }
+            }
+          }
+          .control {
+            flex: 1 0 100%;
+            margin: 0 0 20px 0;
+            @media (min-width: 750px) {
+              flex: 1 0 auto;
+              margin: 0;
+            }
+            &.search {
+              display: inline-flex;
+              font-size: 1.4rem;
+              @media (min-width: 1000px) {
+                font-size: inherit;
+                width: 100%;
+                max-width: 400px;
+              }
+              input {
+                padding-right: 35px;
+              }
+              .filter {
+                width: 35px;
+                height: 3.7rem;
+                margin-left: -35px;
+                padding: 8px 4px 4px;
+                --outline-color: #888;
+                fill: #fff;
+              }
+              .icon-search {
+                font-size: 2.4rem;
+                padding: 8px 4px 4px;
+                margin-left: -35px;
+                color: #555;
+              }
+            }
+          }
+          .filters {
+            flex: 1 0 auto;
+            display: flex;
+            flex-wrap: wrap;
+            max-width: 100%;
+            @media (min-width: 750px) {
+              justify-content: flex-start;
+            }
+            .control {
+              align-items: center;
+              @media (min-width: 750px) {
+                margin: 0 30px 0 0;
+              }
+              label {
+                margin-right: 10px;
+                font-family: $font-family-light;
+                font-weight: normal;
+              }
+            }
+            .custom-combobox {
+              @media (min-width: 750px) {
+                margin-bottom: 20px;
+              }
+            }
+          }
+        }
+      }
+      .wr {
+        display: grid;
+        overflow: hidden;
+        grid-template-columns: repeat(1, 1fr);
+        // grid-auto-rows: minmax(auto, 150px);
+        grid-row-gap: 20px;
+        padding-top: 20px;
+        .row {
+          display: flex;
+          flex-flow: column;
+          padding-bottom: 10px;
+          border-bottom: 1px solid #96969633;
+          @media (min-width: 750px) {
+            padding-bottom: 30px;
+          }
+          .blog-title {
+            text-align: left !important;
+            margin-bottom: 1rem;
+            a {
+              color: inherit;
+              &:after {
+                content: "\f101";
+                display: inline-block;
+                margin-left: 0.5rem;
+                color: $color-highlight;
+                font: normal normal normal 14px/1 FontAwesome;
+                font-size: inherit;
+                text-rendering: auto;
+                -webkit-font-smoothing: antialiased;
+              }
+            }
+          }
+          .blog-details {
+            display: flex;
+            flex-flow: column;
+            align-items: flex-start;
+            margin-bottom: 10px;
+            .publishdate {
+              display: none;
+            }
+            span {
+              font-size: 1.4rem;
+              display: block;
+              font-family: var(--font-family-light);
+              margin-top: 4px;
+              .fa {
+                margin-right: 5px;
+              }
+            }
+            .authors {
+              display: flex;
+              justify-content: center;
+              align-items: flex-start;
+              flex-wrap: wrap;
+              a {
+                .user-icon {
+                  display: block;
+                  margin: 0 auto;
+                  width: 40px;
+                  border-radius: 50%;
+                }
+              }
+              .author {
+                display: flex;
+                font-size: 1.3rem;
+                text-align: center;
+                line-height: 1.5;
+                &:not(:last-child) {
+                  padding-right: 15px;
+                }
+                &:not(:first-child) {
+                  padding-left: 15px;
+                  border-left: 1px solid #cecece;
+                  border-image: linear-gradient(
+                      to bottom,
+                      #cecece,
+                      rgba(255, 255, 255, 0)
+                    )
+                    1 100%;
+                }
+              }
+              li.author {
+                margin: 5px;
+              }
+            }
+            ul.authors {
+              margin: 0px;
+              padding-left: 0px !important;
+            }
+          }
+          .annotation {
+            padding: 0;
+            margin-top: 1.5rem;
+            border-bottom: none;
+            font-size: 1.4rem;
+            font-family: $font-family-book;
+            line-height: 1.2;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            h1:first-child,
+            h2:first-child {
+              font-size: 2rem;
+              margin-bottom: 0.5rem;
+              a {
+                color: inherit;
+              }
+            }
+            p,
+            ul,
+            li {
+              font-size: 1.4rem;
+              line-height: 1.2;
+              overflow: hidden;
+              text-overflow: ellipsis;
+            }
+            img,
+            object,
+            blockquote,
+            table {
+              display: none !important;
+            }
+            ul {
+              padding-left: 40px;
+              li {
+                list-style-position: outside;
+              }
+            }
+            .icon.inline {
+              width: 1em;
+              height: auto;
+            }
+          }
+          a.readmore {
+            align-self: flex-end;
+            font-size: 1.35rem;
+            &:after {
+              content: "\f101";
+              display: inline-block;
+              margin-left: 2px;
+              font: normal normal normal 14px/1 FontAwesome;
+              font-size: inherit;
+              text-rendering: auto;
+              -webkit-font-smoothing: antialiased;
+            }
+          }
+        }
+      }
+    }
+    .page-nav {
+      flex: 1 0 100%;
+      position: sticky;
+      top: var(--header-height);
+      overflow: hidden;
+      height: 100%;
+      margin-left: -94.75%;
+      margin-top: -5rem;
+      background: #fff;
+      box-shadow: -4px 11px 7px -4px #555;
+      @media (min-width: 1000px) {
+        flex: 1 0 30%;
+        position: relative;
+        margin-left: 0;
+        margin-top: 0rem;
+        padding-left: 4%;
+        box-shadow: none;
+      }
+      .menu-toggler {
+        display: block;
+        font-size: 3rem;
+        border-radius: 50%;
+        margin: 0rem 0 2rem;
+        width: 30px;
+        text-align: center;
+        @media (min-width: 1000px) {
+          display: none;
+        }
+      }
+      .menu {
+        width: 90%;
+        position: fixed;
+        right: 0;
+        padding: 1rem 0 1rem 1.6rem;
+        overflow-y: auto;
+        max-height: 100%;
+        background: #fff;
+        box-shadow: -4px 4px 7px -4px #555;
+        transition: all 0.25s;
+        @media (min-width: 1000px) {
+          position: relative;
+          display: initial !important;
+          width: 30%;
+          margin-top: 5rem;
+          margin-left: 0;
+          padding-top: 0;
+          padding-left: 0;
+          box-shadow: none;
+        }
+        &.collapsed {
+          display: none;
+          // margin-left: -7%;
+        }
+        ul {
+          padding-left: 0 !important;
+          li {
+            max-width: 100%;
+            word-wrap: break-word;
+          }
+        }
+      }
+    }
+  }
+}

--- a/hugo/assets/sass/_blog.scss
+++ b/hugo/assets/sass/_blog.scss
@@ -1,8 +1,3 @@
-// table,
-// td {
-//   border: 0;
-// }
-
 .blogs {
   .authors {
     display: flex;
@@ -32,7 +27,7 @@
     margin-top: 5px;
     color: #555;
     font-family: $font-family-light;
-  } 
+  }
   a.title-link {
     color: #b6b6b6;
     text-decoration: none;
@@ -43,17 +38,24 @@
   a.title-link:hover {
     color: $color-highlight;
   }
-  .nav-link+.post {
+  .nav-link + .post {
     border: none;
   }
   .post {
     padding: 30px 0;
     border-bottom: 1px solid #96969633;
-    &:first-of-type {
-      padding-top: 0px;
-    }
+    font-family: $font-family-book;
     .wrapper {
       overflow: hidden;
+      padding-bottom: 30px;
+      h1:first-child,
+      h2:first-child {
+        // font-size: 2rem;
+        margin-bottom: 0.5rem;
+        a {
+          color: inherit;
+        }
+      }
       td {
         border-bottom: 0;
       }
@@ -76,10 +78,11 @@
       .user-icon {
         display: block;
         margin: 0 auto;
-        width: 60px;
+        width: 48px;
         border-radius: 50%;
       }
-      img.inline, object[type="image/svg+xml"].inline {
+      img.inline,
+      object[type="image/svg+xml"].inline {
         display: inline-block;
         margin: 0px 3px;
       }
@@ -114,3 +117,6 @@
     }
   }
 }
+
+
+@import "blog-home";

--- a/hugo/layouts/blog/blog-list.html
+++ b/hugo/layouts/blog/blog-list.html
@@ -1,47 +1,133 @@
 {{ define "page-content"}}
-  <script src="/js/moment.js"></script>
-  <div class="page blogs">
-    <!-- Ranges through content/blog/*.md -->
-    {{ with .Site.GetPage "blog" }}
-    {{ range $index, $page :=  sort (where (where .Site.Pages "Type" "in" (slice "blog" "Blog")) "Params.aggregate" "!=" true) ".Params.publishdate" "desc"}}
-    {{if $page.Params.publishdate}}
-      {{$publishTime := time $page.Params.publishdate}}
-      {{if $publishTime.Before now}}
-    <article class="post row" data-path="">
-      <div class="wrapper">
-          <div class="two columns">
-              {{partial "blog-authors" .}}
-          </div>
-          <div class="ten columns">
-              <h2>{{ .Title }}<a href="{{$page.URL | relURL}}" class="title-link clipboard-copy"><i class="fa fa-link"></i></a></h2>
-              <div class="share-ribbon">
-                <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="{{ .Title }}" data-url="{{$page.URL | absURL}}" data-hashtags="GardenerProject" data-dnt="true" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                <script type="IN/Share" data-url="{{.Permalink}}"></script>
-                <!--button class="btn copy-url clipboard-copy" data-clipboard-text="{{$page.URL | absURL}}" href="{{$page.URL | absURL}}"><i class="fa fa-copy"></i></button-->
-              </div>
-              <p>
-                {{.Content}}
-              </p>
-          </div>
+  <!-- <script src="/js/moment.js"></script> -->
+  {{ $assetBusting := not .Site.Params.disableAssetsBusting }}
+  <script src="{{"jquery-ui-1.12.1/jquery-ui.min.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
+  <link rel="stylesheet" href="{{"jquery-ui-1.12.1/jquery-ui.min.css"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}">
+  <div class="blogs home">
+    <div class="list">
+      <div class="topbar controls">
+        <a href="#" class="menu-toggler"><i class="fa fa-angle-double-left"></i></a>
+        <div class="control search">
+          <input type="text" placeholder="type to filter blogs by title or text" data-filter=".blogs article" data-filter-scope="freetext tags"/>
+          <svg class="icon filter" aria-hidden="true" focusable="false">
+            <use xlink:href="{{"images/icons/icons.svg#filter-o"| relURL}}"></use>
+          </svg>
+        </div>
+        <!-- TODO -->
+        <!--a href="#" class="nav-link">Write a Blog Post</a-->
       </div>
-    </article>
+      <div class="wr">
+      <!-- Ranges through content/blog/*.md -->
+      {{ with .Site.GetPage "blog" }}
+      {{ range $index, $page :=  sort (where (where .Site.Pages "Type" "in" (slice "blog" "Blog")) "Params.aggregate" "!=" true) ".Params.publishdate" "desc"}}
+      {{if $page.Params.publishdate}}
+        {{$publishTime := time $page.Params.publishdate}}
+        {{if $publishTime.Before now}}
+        <article class="row">
+          <h4 data-filter-freetext class="blog-title"><a href="{{.RelPermalink}}">{{ .Title }}</a></h4>
+          <div class="blog-details">
+            {{partial "blog-authors" .}}
+            {{with .Params.publishdate}}
+            <span class="blog-publish-date"><i class="fa fa-calendar" aria-hidden="true"></i> {{.Format "Jan 06, 2006"}}</span>
+            {{end}}
+            <span class="readtime"><i class="fa fa-clock-o" aria-hidden="true"></i> Read Time: {{.ReadingTime}} min</span>
+          </div>
+          <div data-filter-freetext class="annotation">
+            {{ or .Description .Content | truncate 200 }}
+          </div>
+          <a href="{{.RelPermalink}}" class="readmore">Continue reading</a>
+        </article>
+        {{end}}
       {{end}}
-    {{end}}
-    {{end}}
-    {{end}}
+      {{end}}
+      {{end}}
+      </div>
+    </div>
+    <div class="page-nav">
+      <nav class="collapsed menu">
+        <a href="#" class="menu-toggler"><i class="fa fa-angle-double-right"></i></a>
+        <div class="highlightable">
+          <ul class="blogs-list">
+          {{ $pages :=  sort (where (where .Site.Pages "Type" "in" (slice "blog" "Blog")) "Params.aggregate" "!=" true) ".Params.publishdate" "desc"}}
+          {{ range $pages.GroupByPublishDate "Jan 2006" }}
+          <h4>{{.Key}}</h4>
+          <ul>
+            {{ range .Pages }}
+            {{- $hiddenChildrenCount:= len (where .Pages ".Params.hidden" true) -}}
+            {{- $childrenCount:= (len .Pages) -}}
+            {{- $isContainer := and (gt $childrenCount 0) (gt $childrenCount $hiddenChildrenCount) -}}
+            <li data-nav-id="{{.URL}}" title="{{.Title}}" class="dd-item{{- if $isContainer }} collapsible{{end -}}">
+              {{- if $isContainer }} 
+              <span class="toggle fa fa-angle-right"></span>
+              {{- else -}}
+              <span class="toggle"></span>
+              {{- end -}}
+              <a href="{{ .Permalink }}">
+              {{- if $isContainer }} 
+                <span class="toggle fa fa-angle-right"></span>
+              {{- else -}}
+                <span class="toggle"></span>
+              {{- end -}}
+                <span class="menu-item-text">{{- or .Params.menuTitle .LinkTitle .Title -}}{{- safeHTML .Params.Post -}}</span>
+              </a>
+              <!--div class="meta">{{ .Date.Format "Mon, Jan 2, 2006" }}</div-->
+            </li>
+            {{ end }}
+          </ul>
+          {{- end -}}
+          </ul>
+        </div>
+      </nav>
+    </div>
   </div>
 
-{{ end }}
-
-{{ define "tails-scripts-custom" }}
-  <script src="/js/modernizr.custom.min.js"></script>
-  <script src="/js/jsrender.min.js"></script>
-  <script src="/js/main.js"></script>
+  <script src="{{"js/filters.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
   <script>
     $(document).ready(function(){
-      $('.blogs .clipboard-copy').click(function(e){
-        e.preventDefault();
+      // hide sections that have no child tiles
+      function hideSectionIfEmpty(){
+        $('.docs .list section').each(function(){
+          var els = $(".tile", this).filter(function(){
+            return $(this).css('display') !== 'none';
+          })
+          if (els.length < 1) {
+            $(this).addClass("hidden");
+          } else {
+            $(this).removeClass("hidden");
+          }
+        });
+      }
+      $("input[data-filter-scope]", ".guides").on('input', function(evt, ui){
+        $(this).attr('data-filter-value', $(this).val());
       });
-    })
+      $("input[data-filter]").on('elements-filter:complete', function(evt, total, filtered, visible){
+        $('.records-shown').text(visible);
+        $('.records-total').text(total);
+        $("input[data-filter]").not($(this)).val('');
+        $('.docs .list section').show();
+        hideSectionIfEmpty();
+        var queryString = new URLSearchParams(window.location.search);
+        queryString.set("filter-value",$(this).attr("data-filter-value"))
+        if($(this).attr("data-filter-scope").indexOf("freetext") < 0) {
+          queryString.set("filter-name",$(this).attr("data-filter-scope"));
+        }
+        if (history.pushState) {
+          var newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + queryString.toString();
+          window.history.pushState({path:newurl},'',newurl);
+        }
+        return false;
+      });
+      $("input[data-filter]").filterControl();
+
+      $(".blogs .menu-toggler").click(function() {
+        $(".blogs .menu").toggleClass("collapsed")
+        var togglerIcon = $(".blogs .menu-toggler .fa");
+        if($(".blogs .menu").hasClass("collapsed")) {
+          togglerIcon.removeClass("fa-angle-double-right").addClass("fa-angle-double-left");
+        } else {
+          togglerIcon.removeClass("fa-angle-double-left").addClass("fa-angle-double-right");
+        }
+      })
+    });
   </script>
 {{end}}

--- a/hugo/layouts/partials/blog-authors.html
+++ b/hugo/layouts/partials/blog-authors.html
@@ -14,7 +14,7 @@
 <ul class="authors">
 {{ with .Params.authors }}
     {{ range . }}
-    {{- template "author" dict "name" .name "email" .email "avatar" .avatar -}}
+    {{- template "blog-author" dict "name" .name "email" .email "avatar" .avatar -}}
     {{ end }}
 {{else}}
 {{- with .File -}}
@@ -23,7 +23,7 @@
     {{- if (fileExists $url) -}}
       {{- $data := (getJSON $url) -}}
       {{ with $data.author }}
-      {{- template "author" dict "name" .name "email" .email "avatar" .avatar_url -}}
+      {{- template "blog-author" dict "name" .name "email" .email "avatar" .avatar_url -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
@@ -34,23 +34,22 @@
 <span class="publishdate" data-publishdate="{{ . | safeHTMLAttr }}">{{. | safeHTML}}</span>
 {{end}}
 
-{{- define "author" -}}
+{{- define "blog-author" -}}
 {{- $name := .name -}}
 {{- $email := .email -}}
 {{- $avatar := .avatar -}}
 {{- $publishdate := .publishdate -}}
-
 <li class="author">
 {{with $avatar}}
 {{with $email }}<a href="mailto:{{$email | safeHTMLAttr }}">{{end}}
-<img {{ printf "src=%q" . | safeHTMLAttr }}
+  <img {{ printf "src=%q" . | safeHTMLAttr }}
     class="user-icon icons"
     alt="blog author avatar">
 {{else}}
-    <div style="width:10px;height:10px;"></div>
+  <div style="width:10px;height:10px;"></div>
 {{end}}
 {{with $name }}
-<span class="name">{{ $name | safeHTML}}</span>
+  <span class="name">{{ $name | safeHTML}}</span>
 {{with $email }}</a>{{end}}
 {{end}}
 </li>


### PR DESCRIPTION
**What this PR does / why we need it**:
The blogs section used to be listing directly all blogs content. This PR introduces actual blogs home page with basic exploratory functions: 
- filter list by blogs title or annotation
- blogs link shortcuts grouped by Month-Year

The short annotations in the list are rendered from the blogs front matter description (if exists) or its content, truncated intelligently (considering the html) up to 200 rendered symbols. Tags such as images, objects or tables are hidden to be able to make use of the content for that purpose. It is preferable and recommended to use the description and only fallback to the content to derive short annotation for the blog list only for legacy content.

Added estimated reading time (function from Hugo).

The By-Time navigation list on the right is collapsible on smaller screens and can slide in and out with a button.