### PR TITLE
Blogs tag support

### DIFF
--- a/hugo/assets/sass/_blog-home.scss
+++ b/hugo/assets/sass/_blog-home.scss
@@ -182,13 +182,19 @@
             .publishdate {
               display: none;
             }
-            span {
-              font-size: 1.4rem;
-              display: block;
-              font-family: var(--font-family-light);
-              margin-top: 4px;
-              .fa {
-                margin-right: 5px;
+            .one-liner {
+              display: flex;
+              & > *:not(:last-child) {
+                margin-right: 25px;
+              }
+              span {
+                font-size: 1.4rem;
+                display: block;
+                font-family: var(--font-family-light);
+                margin-top: 4px;
+                .fa {
+                  margin-right: 5px;
+                }
               }
             }
             .authors {
@@ -285,6 +291,16 @@
               font-size: inherit;
               text-rendering: auto;
               -webkit-font-smoothing: antialiased;
+            }
+          }
+          .tags {
+            font-size: 1.2rem;
+            font-family: var(--font-family-book);
+            display: flex;
+            flex-wrap: wrap;
+            margin-top: 5px;
+            & > *:not(:last-child) {
+              margin-right: 4px;
             }
           }
         }

--- a/hugo/layouts/blog/blog-list.html
+++ b/hugo/layouts/blog/blog-list.html
@@ -27,15 +27,25 @@
           <h4 data-filter-freetext class="blog-title"><a href="{{.RelPermalink}}">{{ .Title }}</a></h4>
           <div class="blog-details">
             {{partial "blog-authors" .}}
-            {{with .Params.publishdate}}
-            <span class="blog-publish-date"><i class="fa fa-calendar" aria-hidden="true"></i> {{.Format "Jan 06, 2006"}}</span>
-            {{end}}
-            <span class="readtime"><i class="fa fa-clock-o" aria-hidden="true"></i> Read Time: {{.ReadingTime}} min</span>
+            <div class="one-liner">
+              {{with .Params.publishdate}}
+              <span class="blog-publish-date"><i class="fa fa-calendar" aria-hidden="true"></i> {{.Format "Jan 06, 2006"}}</span>
+              {{end}}
+              <span class="readtime"><i class="fa fa-clock-o" aria-hidden="true"></i> Read Time: {{.ReadingTime}} min</span>
+            </div>
           </div>
           <div data-filter-freetext class="annotation">
             {{ or .Description .Content | truncate 200 }}
           </div>
           <a href="{{.RelPermalink}}" class="readmore">Continue reading</a>
+          {{with .Params.Tags }}
+          <div class="tags">
+            <i class="fa fa-tag" aria-hidden="true"></i>
+            {{range first 5 .}}
+              <span>{{.}}</span>
+            {{end}}
+          </div>
+          {{end}}
         </article>
         {{end}}
       {{end}}

--- a/hugo/layouts/shortcodes/blog_img.html
+++ b/hugo/layouts/shortcodes/blog_img.html
@@ -9,7 +9,6 @@ Usage: {{< img title="title" link="URL" >}}
 
 {{- if not (or (hasPrefix $link "/") (hasPrefix $link "https://") (strings.HasPrefix $link "http://")) -}}
     {{ $pageDir := path.Dir .Page.File.Path }}
-
     {{- if (hasPrefix $link "../") -}}
         {{- $link = printf "/%s/%s" $pageDir (slicestr $link 3) -}}
     {{- else if (hasPrefix $link "./") -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Blogs can be tagged now using front matter property `tags`. Tags will appear with each list item in the home page. Only the first 5 are considered.