### PR TITLE
Preserve git info and history across renames/moves

### DIFF
--- a/.ci/gitlog.sh
+++ b/.ci/gitlog.sh
@@ -5,33 +5,18 @@ set -e
 # the path relative to `content-source-path`.
 # The `content-folder-path` directory is expected to be in a git repo clone.
 #
-# Usage: gitlog.sh content-folder-path(website-generator/hugo/content) content-source-path(documentation/website) output-folder-path(website-generator/hugo/data)
+# Usage: gitlog.sh content-folder-path(website-generator/hugo/content) file-path(documentation/website/documentation/_index.md)
 # All paths are absolute
 function gitlog {
-for _f in "$1"/*
-do
-  f=$(readlink -f "$_f")
-  source=$(readlink -f "$2")
-  data=$(readlink -f "$3")
-  if [[ -d $f ]]
-  then
-    cd $f
-    gitlog $f $source $data
-    cd ..
-  else
-    fileext=${f##*.}
-    if [[ "$fileext" != "md" && "$fileext" != "html" ]]
-    then 
-        continue    
-    fi
-    ESCAPED_KEYWORD=$(printf '%s\n' "$source" | sed -e 's/[]\/$*.^[]/\\&/g');
-    ESCAPED_REPLACE=$(printf '%s\n' "$data" | sed -e 's/[\/&]/\\&/g');
-    filePath=$(echo $f | sed "s/$ESCAPED_KEYWORD/$ESCAPED_REPLACE/g")
-    mkdir -p $(dirname "$filePath")
-    echo "saving commits into $filePath.json"
-    git log --pretty=format:'{%n  "commit": "%H",%n  "author": "%aN <%aE>",%n  "date": "%ad",%n  "message": "%s"%n, },' --follow $f | perl -pe 'BEGIN{print "["}; END{print "]\n"}' | perl -pe 's/},]/}]/' > $filePath.json
-  fi
-done
+cd $(readlink -f "$1")
+file=$(readlink -f "$2")
+if [[ -f $file ]]
+then
+  git log --date=short --pretty=format:'{%n  "sha": "%H",%n  "author": "%aN <%aE>",%n  "date": "%ad",%n  "message": "%s",%n  "email": "%aE",%n  "name": "%aN"%n },' --follow $file | perl -pe 'BEGIN{print "["}; END{print "]\n"}' | perl -pe 's/},]/}]/'
+else
+  echo "not a file: $file"
+  exit 1
+fi
 }
 
-gitlog $1 $2 $3
+gitlog $1 $2

--- a/.ci/gitlog.sh
+++ b/.ci/gitlog.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+set -e
+
+# Description: Retrieve git commits info for files in `content-folder-path` and store it as json files in `output-folder-path` preserving 
+# the path relative to `content-source-path`.
+# The `content-folder-path` directory is expected to be in a git repo clone.
+#
+# Usage: gitlog.sh content-folder-path(website-generator/hugo/content) content-source-path(documentation/website) output-folder-path(website-generator/hugo/data)
+# All paths are absolute
+function gitlog {
+for _f in "$1"/*
+do
+  f=$(readlink -f "$_f")
+  source=$(readlink -f "$2")
+  data=$(readlink -f "$3")
+  if [[ -d $f ]]
+  then
+    cd $f
+    gitlog $f $source $data
+    cd ..
+  else
+    fileext=${f##*.}
+    if [[ "$fileext" != "md" && "$fileext" != "html" ]]
+    then 
+        continue    
+    fi
+    ESCAPED_KEYWORD=$(printf '%s\n' "$source" | sed -e 's/[]\/$*.^[]/\\&/g');
+    ESCAPED_REPLACE=$(printf '%s\n' "$data" | sed -e 's/[\/&]/\\&/g');
+    filePath=$(echo $f | sed "s/$ESCAPED_KEYWORD/$ESCAPED_REPLACE/g")
+    mkdir -p $(dirname "$filePath")
+    echo "saving commits into $filePath.json"
+    git log --pretty=format:'{%n  "commit": "%H",%n  "author": "%aN <%aE>",%n  "date": "%ad",%n  "message": "%s"%n, },' --follow $f | perl -pe 'BEGIN{print "["}; END{print "]\n"}' | perl -pe 's/},]/}]/' > $filePath.json
+  fi
+done
+}
+
+gitlog $1 $2 $3

--- a/node/index.js
+++ b/node/index.js
@@ -18,18 +18,18 @@
  */
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-const glob = require( 'glob' )
+const glob = require('glob')
 const fs = require('fs')
 const fm = require('front-matter')
 const path = require("path")
 const request = require('sync-request')
-const shuffle = require('shuffle-array')
 const moment = require('moment');
+const { spawnSync } = require("child_process");
 
-if (!process.env.CONTENT) { 
+if (!process.env.CONTENT) {
     process.env.CONTENT = path.resolve(__dirname, '/../hugo/content');
 }
-if (!process.env.DATA) { 
+if (!process.env.DATA) {
     process.env.DATA = path.resolve(__dirname, '../hugo/data');
 }
 
@@ -41,270 +41,385 @@ process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
 
 const repoCommits = "https://api.github.com/repos/gardener/documentation/commits"
 
-
-// Parse all files and inline remote MarkDown content.
-//
-glob( process.env.CONTENT+'/**/*.md', function( err, files ) {
-    // We must shuffle the files to process them in a random order...WHY THIS HACK?
-    //
-    // Github.com has some rate limits/hour. But we want to fetch the github commit statistic
-    // for each file. At a dedicated point the github fetch is banned and we didn't get
-    // any info about the commits. In this case we cache the statistic for each file and try to update
-    // the files in a random order. With this strategy, the statistic get better and better for
-    // each build - WHAT A HACK!!!!!!!
-    shuffle(files)
-
-    console.log("Fetching remote content and commits history. This will take a minute..")    
-
-    let requestOptions = {
-        timeout: 10000,
-        headers: {
-            'User-Agent': "NodeJS",
-            "Accept": "application/json"
-        }
+let requestOptions = {
+    timeout: 10000,
+    headers: {
+        'User-Agent': "NodeJS",
+        "Accept": "application/json"
     }
-    // Use authenticated requests to GitHub API if user token or credentials are provided
-    if ('GIT_OAUTH_TOKEN' in process.env) {
-        requestOptions.headers['Authorization'] = "token " + process.env.GIT_OAUTH_TOKEN;
-    } else if ('GIT_USER' in process.env && 'GIT_PASSWORD' in process.env){
-        requestOptions.headers['Authorization'] = "Basic " + new Buffer.from(process.env.GIT_USER + ':' + process.env.GIT_PASSWORD).toString('base64');
-    } else {
-        console.info("GitHub API request are setup for annonymous access. Significant rate limit restriction will apply.");
+}
+// Use authenticated requests to GitHub API if user token or credentials are provided
+if ('GIT_OAUTH_TOKEN' in process.env) {
+    requestOptions.headers['Authorization'] = "token " + process.env.GIT_OAUTH_TOKEN;
+} else if ('GIT_USER' in process.env && 'GIT_PASSWORD' in process.env) {
+    requestOptions.headers['Authorization'] = "Basic " + new Buffer.from(process.env.GIT_USER + ':' + process.env.GIT_PASSWORD).toString('base64');
+} else {
+    console.info("GitHub API request are setup for annonymous access. Significant rate limit restriction will apply.");
+}
+
+function Users() {
+    let userMap = {}
+    this.get = function(commit) {
+        if (userMap[commit.email] === undefined) {
+            console.log("fetching <" + commit.email + "> details from GitHub")
+            let fetchedCommit = JSON.parse(request("GET", repoCommits + "/" + commit.sha, requestOptions).getBody().toString());
+            userMap[commit.email] = Object.assign(fetchedCommit.author, { "email": commit.email });
+        }
+        return userMap[commit.email]
     }
+    this.set = function(identity, userDetails){
+        userMap[identity] = userDetails
+    }
+    this.cache = function(){
+        return userMap;
+    }
+}
 
-    files.forEach(function(file, idx, filesArr){
-        let content;
-        try {
-            content = fm(fs.readFileSync(file, 'utf8'))
-        } catch (err) {
-            console.error("Failed to read front-matter from", file, err);
-            console.log("proceeding with next file")
-            return
+function isGitlogInternalCommit(commit) {
+    return commit.message.startsWith("[int]") || commit.message.indexOf("[skip ci]") > -1 || commit.email.startsWith("gardener.ci");
+}
+
+function escapeJSONString(json) {
+    return json.split("\n").map(function (l) {
+        if (l.indexOf(":") < 0)
+            return l
+        s = l.split(":")
+        v = s[1].trim();
+        if (v.length > 0 && v.startsWith('"') && (v.endsWith('",'))) {
+            s[1] = '"' + v.substring(1, v.lastIndexOf('"')).replace(/"/g, "'") + '",';
         }
-        if (content.attributes.remote) {
-            // transform a normal URL of a file to the RAW version.
-            //
-            let url = content.attributes.remote
+        l = s.join(":")
+        return l;
+    }).join("\n")
+}
 
-            // we reference a complete repository. In this case we fetch the README.md and inline them
-            //
-            if(url.endsWith(".git")){
-                url = url.replace(".git","/blob/master/README.md")
+/* Transforms Git log JSON output to Git info model */
+function transformGitLog(log, users) {
+    let escF = escapeJSONString(log);
+    let commits = JSON.parse(escF);
+    if (!commits || !Array.isArray(commits)) {
+        throw Error('bad input obect type:' + (typeof commits))
+    }
+    let gitInfo;
+    // Clean up from internal commits
+    commits = commits.filter(function (commit) {
+        return commit.email !== undefined && !isGitlogInternalCommit(commit);
+    });
+    if (!commits || commits.length < 1) {
+        return
+    }
+    //sort by date desc (newest first)
+    commits = commits.sort((a, b) => moment(b.date).format('YYYYMMDD') - moment(a.date).format('YYYYMMDD'))
+    gitInfo = {
+        "lastmod": moment(commits[0].date, "YYYY-MM-DD").format("YYYY-MM-DD"),
+        "publishdate": moment(commits[commits.length - 1].date, "YYYY-MM-DD").format("YYYY-MM-DD")
+    };
+    // transform into contributors list enriched with GitHub user details
+    contributors = commits.map(commit => {
+        return users.get(commit)
+    })
+    // store the author (last in the sorted by desc date list)
+    gitInfo["author"] = contributors[commits.length - 1];
+    // clean undefineds, remove author, backtrack and deduplicate by contributor email or name
+    // and store in contributors list
+    gitInfo["contributors"] = contributors.filter((contributor, index, self) => {
+        return contributor != undefined && contributor.email !== gitInfo["author"].email && index === self.findIndex(t => {
+            if (t === undefined) {
+                return false;
             }
+            return t.email === contributor.email || t.name === contributor.name
+        })
+    });
+    return gitInfo;
+}
 
-            // The url points to an external github wiki.
-            // works just for external GITHUB
-            //
-            if(url.indexOf("/wiki/")!==-1) {
-                // Check if we got a link to a GitHub wiki page. In this case we must transform them
-                // to the RAW version as well
-                // e.g. IN: https://github.com/gardener/documentation/wiki/Architecture
-                //     OUT: https://raw.githubusercontent.com/wiki/gardener/documentation/Architecture.md
-                let segments = url.replace("https://github.com/","").split("/")
-                let user = segments[0]
-                let project = segments[1]
-                let doc = segments.slice(3).join("/")+".md"
-                url = "https://raw.githubusercontent.com/wiki/"+user+"/"+project+"/"+doc
+function saveGitInfoLocal(file, users) {
+    console.log(`saving git history for local file ${file}`)
+    let gitlog
+    try {
+        gitlog = spawnSync(".ci/gitlog.sh", [process.env.CONTENT, file], { shell: "/bin/bash", timeout: 5 * 60000 });
+        let data = gitlog.stdout.toString();
+        if (data && data.length) {
+            let gitInfo = transformGitLog(data, users);
+            if (gitInfo && Object.values(gitInfo)) {
+                let gitInfoFilePath = file.replace(process.env.CONTENT, process.env.DATA) + ".json"
+                fs.mkdirSync(path.dirname(gitInfoFilePath), { recursive: true })
+                fs.writeFileSync(gitInfoFilePath, JSON.stringify(gitInfo, null, 2), "utf8");
+            } else {
+                console.log(`no git info for ${file}`);
             }
-            else {
-                // Required to fetch the plain MarkDown instead of the rendered version
-                // Replace the "normal" github URL with the "RAW" API Link
-                //
-                url = url
-                        .replace("https://github.com/" ,"https://raw.githubusercontent.com/")
-                        .replace("/blob/master/", "/master/")
-                        .replace("/tree/master/", "/master/")
-            }
-
-            // Get the content of the referenced MD file and append it to the
-            // Hugo CMS page
-            //
-            try {
-                var remoteContent = fm(request("GET", url).getBody().toString()).body
-                remoteContent = rewriteAndCheckUrls(url, remoteContent, file)
-            } catch(err) {
-                console.error("Unable to get remote content for",url, err)
-                console.log("proceeding with next file")
-                return
-            }
-
-            // Finally, write the file
-            let newDoc = [
-                "---",
-                content.frontmatter,
-                "---",
-                remoteContent].join("\n")
-            console.log("writing remote content to", file)
-            fs.writeFileSync(file, newDoc, 'utf8');
-        }
-
-        // ====================================================
-        // try to fetch the github changes for the file
-        // ====================================================
-        // e.g. https://api.github.com/repos/gardener/gardener/commits?path=README.md
-        //
-        let commitsUrl = repoCommits
-        let relUrl = ""
-        if (content.attributes.remote) {
-            let changesUrl = content.attributes.remote;
-            if (changesUrl.endsWith(".git")) {
-                changesUrl = changesUrl.replace(".git", "/README.md")
-            }
-
-            let segments = changesUrl.replace("https://github.com/", "").split("/")
-            let user = segments[0]
-            let project = segments[1]
-
-            relUrl = changesUrl
-                .replace("/blob/master", "")
-                .replace("https://github.com/" + user + "/" + project, "")
-            commitsUrl = ["https://api.github.com/repos", user, project, "commits"].join("/")
-
         } else {
-            relUrl = file.replace(process.env.CONTENT,"/website")
+            throw Error('failed to get valid git log output');
         }
+    } catch (err) {
+        console.error(`updating git info for ${file} failed: ${err}`);
+    }
+}
 
-        commitsUrl = commitsUrl + "?path=" + relUrl;
-        console.debug("Fetching commits", commitsUrl);
-        try {
-            let commits = request("GET", commitsUrl, requestOptions).getBody().toString()
-            if (commits.length > 0) {
-                try {
-                    commits = JSON.parse(commits);
-                    if (commits.length > 0) {
-                        let gitInfo = {};
-                        // Commits are sorted desc by date
-                        // Check for lastmodified date, skipping internal commits
-                        var lastCommit = commits.find( commit => {
-                            return !isInternalCommit(commit.commit)
-                        });
-                        if (lastCommit !== undefined) {
-                            gitInfo["lastmod"] = moment(lastCommit.commit.committer.date).format("YYYY-MM-DD HH:mm:ss");
-                        }
-                        // Update front-matter if necesary
-                        // Find the first committhat is not internal (should be the last element, but let's be sure)
-                        let firstCommit;
-                        for ( var i = commits.length-1; i >= 0; i-- ) {
-                            if (!isInternalCommit(commits[i].commit)) {
-                                firstCommit = commits[i];
-                                break;
-                            }
-                        }
-                        if (firstCommit !== undefined){
-                            gitInfo["publishdate"] = moment(firstCommit.commit.committer.date).format("YYYY-MM-DD HH:mm:ss");
-                            let author = firstCommit.commit.author;
-                            if (author !== undefined && firstCommit.author !== undefined){
-                                author = Object.assign(author, firstCommit.author);
-                            } else {
-                                author = firstCommit.committer;
-                                author = Object.assign(author, firstCommit.author);
-                            } 
-                            gitInfo["author"] = author;
-                        }
-                        if (commits.length > 1) {
-                            gitInfo["contributors"] = commits.map(commit => {
-                                if( !isInternalCommit(commit.commit) ){
-                                    let contributor = commit.commit.author;
-                                    if (contributor !== undefined && commit.author !== undefined){
-                                        contributor = Object.assign(contributor, commit.author);
-                                    } else {
-                                        contributor = commit.commit.committer;
-                                        contributor = Object.assign(contributor, commit.committer);
-                                    } 
-                                    if (contributor.email !== gitInfo["author"].email) {
-                                        return contributor;
-                                    }
-                                }
-                                return
-                            }).filter( (el, index, self) => {
-                                // clean undefineds, backtrack and deduplicate by contributor email or name
-                                return el != undefined && index === self.findIndex( t => {
-                                    if ( t === undefined ){
-                                        return false;
-                                    }
-                                    return t.email === el.email || t.name === el.name
-                                })
-                            });
-                        }
-                        gitInfoStr = JSON.stringify(gitInfo, undefined, 2);
-                        datafilePath = file.replace(process.env.CONTENT, process.env.DATA) + ".json"
-                        fs.mkdirSync(path.dirname(datafilePath), { recursive: true })
-                        fs.writeFileSync(datafilePath, gitInfoStr)
-                        console.debug("Writing git info: ", datafilePath);
-                    } else {
-                        console.error("Skip commits json update: unexpected json `[]`", commitsUrl);
-                        console.log("proceeding with next file")
-                        return
-                    }
-                } catch (err){                          
-                    console.error("Invalid JSON content from", commitsUrl, err);
-                    console.log("proceeding with next file")
-                    return
-                }
+// ====================================================
+// try to fetch the github changes for the file
+// ====================================================
+// e.g. https://api.github.com/repos/gardener/gardener/commits?path=README.md
+//
+function saveGitInfoRemote(file, remoteUrl, users) {
+    let commitsUrl = repoCommits
+    let relUrl = ""
+    if (remoteUrl.endsWith(".git")) {
+        remoteUrl = remoteUrl.replace(".git", "/README.md")
+    }
+
+    let segments = remoteUrl.replace("https://github.com/", "").split("/")
+    let user = segments[0]
+    let project = segments[1]
+
+    relUrl = remoteUrl
+        .replace("/blob/master", "")
+        .replace("https://github.com/" + user + "/" + project, "")
+    commitsUrl = ["https://api.github.com/repos", user, project, "commits"].join("/")
+
+    commitsUrl = commitsUrl + "?path=" + relUrl;
+    console.debug("Fetching commits", commitsUrl);
+    try {
+        let commits = request("GET", commitsUrl, requestOptions).getBody().toString()
+        if (commits.length > 0) {
+            let gitInfo = transformGitHubCommits(commits, users);
+            if (gitInfo) {
+                gitInfoStr = JSON.stringify(gitInfo, undefined, 2);
+                let datafilePath = file.replace(process.env.CONTENT, process.env.DATA) + ".json"
+                fs.mkdirSync(path.dirname(datafilePath), { recursive: true })
+                console.debug("Writing git info: ", datafilePath);
+                fs.writeFileSync(datafilePath, gitInfoStr, "utf8")
             } else {
                 console.error("Skip commits json update: unexpected json `[]`", commitsUrl);
                 console.log("proceeding with next file")
                 return
             }
-        } catch (err) {
-            console.error("Failed to update commits json from", commitsUrl, err);
+        } else {
+            console.error("Skip commits json update: unexpected json `[]`", commitsUrl);
             console.log("proceeding with next file")
             return
         }
-    })
+    } catch (err) {
+        console.error("Failed to update commits json from", commitsUrl, err);
+        console.log("proceeding with next file")
+        return
+    }
+}
 
-    // Parse all MarkdownFiles and check if any link reference to a remote site which we have imported.
-    // In this case we REWRITE the link from REMOTE to LOCAL
+function isGitHubInternalCommit(commit) {
+    return commit.message.startsWith("[int]") || commit.message.indexOf("[skip ci]") > -1 || commit.committer.email.startsWith("gardener.ci");
+}
+
+/* transforms GitHub API commits model to Git info */
+function transformGitHubCommits(commits, users) {
+    try {
+        commits = JSON.parse(commits);
+        if (commits.length > 0) {
+            let gitInfo = {};
+            // Commits are sorted desc by date
+            // Check for lastmodified date, skipping internal commits
+            var lastCommit = commits.find(commit => {
+                return !isGitHubInternalCommit(commit.commit)
+            });
+            if (lastCommit !== undefined) {
+                gitInfo["lastmod"] = moment(lastCommit.commit.committer.date).format("YYYY-MM-DD HH:mm:ss");
+            }
+            // Find the first commit that is not internal (should be the last element, but let's be sure)
+            let firstCommit;
+            for (var i = commits.length - 1; i >= 0; i--) {
+                if (!isGitHubInternalCommit(commits[i].commit)) {
+                    firstCommit = commits[i];
+                    break;
+                }
+            }
+            if (firstCommit !== undefined) {
+                gitInfo["publishdate"] = moment(firstCommit.commit.committer.date).format("YYYY-MM-DD HH:mm:ss");
+                let author = firstCommit.commit.author;
+                if (author !== undefined && firstCommit.author !== undefined) {
+                    author = Object.assign(author, firstCommit.author);
+                } else {
+                    author = firstCommit.committer;
+                    author = Object.assign(author, firstCommit.author);
+                }
+                gitInfo["author"] = author;
+            }
+            if (commits.length > 1) {
+                gitInfo["contributors"] = commits.map(commit => {
+                    if (!isGitHubInternalCommit(commit.commit)) {
+                        let contributor = commit.commit.author;
+                        users.set(contributor.email, contributor)
+                        if (contributor !== undefined && commit.author !== undefined) {
+                            contributor = Object.assign(contributor, commit.author);
+                        } else {
+                            contributor = commit.commit.committer;
+                            contributor = Object.assign(contributor, commit.committer);
+                        }
+                        if (contributor.email !== gitInfo["author"].email) {
+                            return contributor;
+                        }
+                    }
+                    return
+                }).filter((el, index, self) => {
+                    // clean undefineds, backtrack and deduplicate by contributor email or name
+                    return el != undefined && index === self.findIndex(t => {
+                        if (t === undefined) {
+                            return false;
+                        }
+                        return t.email === el.email || t.name === el.name
+                    })
+                });
+            }
+            return gitInfo
+        } else {
+            console.error("Skip commits json update: unexpected json `[]`");
+            console.log("proceeding with next file")
+            return
+        }
+    } catch (err) {
+        console.error("Invalid JSON content from", err);
+        console.log("proceeding with next file")
+        return
+    }
+}
+
+function processContent() {
+    // Parse all files and inline remote MarkDown content.
     //
-    glob(process.env.CONTENT + '/**/*.md', function( err, files ) {
-        var docPath = path.normalize(process.env.CONTENT)
-        var importedMarkdownFiles = []
-        // collect all remote links in the "front matter" annotations
-        //
-        files.forEach(function (file) {
-            let content;
-            try{
-                content = fm(fs.readFileSync(file, 'utf8'));
-            } catch (err) {
-                console.error("Failed to read front-matter from", file, err);
-                console.log("proceeding with next file")
-                return
-            }
-            if (content.attributes.remote) {
-                importedMarkdownFiles.push({file:file.replace(docPath,"/"),remote:content.attributes.remote})
-            }
-        })
-
-        // check if any MD files referer to a imported page. In this case we rewrite the link to the
-        // internal document
-        //
-        files.forEach(function (file) {
+    glob(process.env.CONTENT + '/**/*.md', function (err, files) {
+        console.log("Fetching content and commits history. This will take a minute..")
+        let users = new Users;
+        files.forEach(file => {
             let content;
             try {
-                content = fm(fs.readFileSync(file, 'utf8'));
+                content = fm(fs.readFileSync(file, 'utf8'))
             } catch (err) {
                 console.error("Failed to read front-matter from", file, err);
                 console.log("proceeding with next file")
                 return
             }
             if (content.attributes.remote) {
-                let md = content.body;
-                importedMarkdownFiles.forEach(function(entry){
-                    md = md.split(entry.remote).join("{{< ref \""+entry.file+"\" >}}")
-                })
+                // transformGitLog a normal URL of a file to the RAW version.
+                //
+                let url = content.attributes.remote
+
+                // we reference a complete repository. In this case we fetch the README.md and inline them
+                //
+                if (url.endsWith(".git")) {
+                    url = url.replace(".git", "/blob/master/README.md")
+                }
+
+                // The url points to an external github wiki.
+                // works just for external GITHUB
+                //
+                if (url.indexOf("/wiki/") !== -1) {
+                    // Check if we got a link to a GitHub wiki page. In this case we must transform them
+                    // to the RAW version as well
+                    // e.g. IN: https://github.com/gardener/documentation/wiki/Architecture
+                    //     OUT: https://raw.githubusercontent.com/wiki/gardener/documentation/Architecture.md
+                    let segments = url.replace("https://github.com/", "").split("/")
+                    let user = segments[0]
+                    let project = segments[1]
+                    let doc = segments.slice(3).join("/") + ".md"
+                    url = "https://raw.githubusercontent.com/wiki/" + user + "/" + project + "/" + doc
+                }
+                else {
+                    // Required to fetch the plain MarkDown instead of the rendered version
+                    // Replace the "normal" github URL with the "RAW" API Link
+                    //
+                    url = url
+                        .replace("https://github.com/", "https://raw.githubusercontent.com/")
+                        .replace("/blob/master/", "/master/")
+                        .replace("/tree/master/", "/master/")
+                }
+
+                // Get the content of the referenced MD file and append it to the
+                // Hugo CMS page
+                //
+                try {
+                    var remoteContent = fm(request("GET", url).getBody().toString()).body
+                    remoteContent = rewriteAndCheckUrls(url, remoteContent, file)
+                } catch (err) {
+                    console.error("Unable to get remote content for", url, err)
+                    console.log("proceeding with next file")
+                    return
+                }
+
+                // Finally, write the file
                 let newDoc = [
                     "---",
                     content.frontmatter,
                     "---",
-                    md].join("\n")
-                console.log("updating content in", file)
+                    remoteContent].join("\n")
+                console.log("writing remote content to", file)
                 fs.writeFileSync(file, newDoc, 'utf8');
+
+                saveGitInfoRemote(file, content.attributes.remote, users)
+
+            } else {
+
+                // Update git info for local files
+                saveGitInfoLocal(file, users);
             }
+
         })
 
-    })
-});
+        let contributorsFile = process.env.DATA + "/contributors.json"
+        let contributors = Object.values(users);
+        if (contributors) {
+            fs.writeFileSync(contributorsFile, JSON.stringify(contributors, null, 2), 'utf8')
+        }
 
-function isInternalCommit(commit){
-    return commit.message.startsWith("[int]") || commit.message.indexOf("[skip ci]") > -1;
+        // Parse all MarkdownFiles and check if any link reference to a remote site which we have imported.
+        // In this case we REWRITE the link from REMOTE to LOCAL
+        //
+        glob(process.env.CONTENT + '/**/*.md', function (err, files) {
+            var docPath = path.normalize(process.env.CONTENT)
+            var importedMarkdownFiles = []
+            // collect all remote links in the "front matter" annotations
+            //
+            files.forEach(function (file) {
+                let content;
+                try {
+                    content = fm(fs.readFileSync(file, 'utf8'));
+                } catch (err) {
+                    console.error("Failed to read front-matter from", file, err);
+                    console.log("proceeding with next file")
+                    return
+                }
+                if (content.attributes.remote) {
+                    importedMarkdownFiles.push({ file: file.replace(docPath, "/"), remote: content.attributes.remote })
+                }
+            })
+
+            // check if any MD files referer to a imported page. In this case we rewrite the link to the
+            // internal document
+            //
+            files.forEach(function (file) {
+                let content;
+                try {
+                    content = fm(fs.readFileSync(file, 'utf8'));
+                } catch (err) {
+                    console.error("Failed to read front-matter from", file, err);
+                    console.log("proceeding with next file")
+                    return
+                }
+                if (content.attributes.remote) {
+                    let md = content.body;
+                    importedMarkdownFiles.forEach(function (entry) {
+                        md = md.split(entry.remote).join("{{< ref \"" + entry.file + "\" >}}")
+                    })
+                    let newDoc = [
+                        "---",
+                        content.frontmatter,
+                        "---",
+                        md].join("\n")
+                    console.log("updating content in", file)
+                    fs.writeFileSync(file, newDoc, 'utf8');
+                }
+            })
+
+        })
+    });
 }
+
+processContent();


### PR DESCRIPTION
**What this PR does / why we need it**:
Restructuring documentation lead to loss of git-related info intended to be shown on the documentation pages  - committers most notably. The reason is, that the current method for gathering such git info is via getting files commit history from GitHub API and it doesn't support history across rename or move operations on a file (unlike `git log --follow`).

This PR introduces a new method to get git info that uses the GitHub API more sparingly and relies on information from `git log` for local files where applicable. The `git log` output is missing GitHub related details (e.g. usernames and avatar urls) and it is complemented with additional contributors info from GitHub, as necessary.

The node script that fetches git commits changed to invoke a shell script as child process that executes `git log --follow` with output formatted as JSON. The output is then enriched with GitHub user details and converted to the git info JSON format that is consumed by Hugo. As a nice side effect it also generates a list of contributors (`contributors.json`) - all commit authors for local or remote pages in the website.

Note: 
- The produced git info is stripped from the authors of internal commits (by gardener ci user or marked explicitly internal with `[int]` or `[skip-ci]` tags). The publish and last modified dates are also dates for non-internal commits (first and last correspondingly).
- It takes some minutes to read/write files and fetch remote content because of the sequential nature of the script. Moving this into parallel execution will dramatically increase the performance. NodeJS is not the best way to achieve that and migration to another platform/language such as Python or Go will make more sense to address this issue.