### PR TITLE
Fix no contributors due to git log failing to execute

### DIFF
--- a/.ci/gitlog.sh
+++ b/.ci/gitlog.sh
@@ -8,8 +8,10 @@ set -e
 # Usage: gitlog.sh content-folder-path(website-generator/hugo/content) file-path(documentation/website/documentation/_index.md)
 # All paths are absolute
 function gitlog {
-cd $(readlink -f "$1")
+content=$(readlink -f "$1")
 file=$(readlink -f "$2")
+file=${file#$(echo $content)/}
+cd $content
 if [[ -f $file ]]
 then
   git log --date=short --pretty=format:'{%n  "sha": "%H",%n  "author": "%aN <%aE>",%n  "date": "%ad",%n  "message": "%s",%n  "email": "%aE",%n  "name": "%aN"%n },' --follow $file | perl -pe 'BEGIN{print "["}; END{print "]\n"}' | perl -pe 's/},]/}]/'

--- a/node/index.js
+++ b/node/index.js
@@ -108,18 +108,18 @@ function transformGitLog(log, users) {
     if (!commits || commits.length < 1) {
         return
     }
-    //sort by date desc (newest first)
-    commits = commits.sort((a, b) => moment(b.date).format('YYYYMMDD') - moment(a.date).format('YYYYMMDD'))
+    //sort by date asc (newest last)
+    commits = commits.sort((a, b) => moment(a.date).format('YYYYMMDD') - moment(b.date).format('YYYYMMDD'))
     gitInfo = {
-        "lastmod": moment(commits[0].date, "YYYY-MM-DD").format("YYYY-MM-DD"),
-        "publishdate": moment(commits[commits.length - 1].date, "YYYY-MM-DD").format("YYYY-MM-DD")
+        "lastmod": moment(commits[commits.length - 1].date, "YYYY-MM-DD").format("YYYY-MM-DD"),
+        "publishdate": moment(commits[0].date, "YYYY-MM-DD").format("YYYY-MM-DD")
     };
     // transform into contributors list enriched with GitHub user details
     contributors = commits.map(commit => {
         return users.get(commit)
     })
-    // store the author (last in the sorted by desc date list)
-    gitInfo["author"] = contributors[commits.length - 1];
+    // store the author (the first contributor)
+    gitInfo["author"] = contributors[0];
     // clean undefineds, remove author, backtrack and deduplicate by contributor email or name
     // and store in contributors list
     gitInfo["contributors"] = contributors.filter((contributor, index, self) => {
@@ -364,7 +364,7 @@ function processContent() {
         })
 
         let contributorsFile = process.env.DATA + "/contributors.json"
-        let contributors = Object.values(users);
+        let contributors = Object.values(users.cache());
         if (contributors) {
             fs.writeFileSync(contributorsFile, JSON.stringify(contributors, null, 2), 'utf8')
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -568,11 +568,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "shuffle-array": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/shuffle-array/-/shuffle-array-1.0.1.tgz",
-      "integrity": "sha1-xP88/nTRb5NzBZIwGyXmV3sSiYs="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "glob": "7.1.6",
     "is-relative-url": "3.0.0",
     "moment": "^2.26.0",
-    "shuffle-array": "^1.0.1",
     "sync-request": "6.1.0",
     "url-exists": "1.0.3"
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with failure to get contributors for a local source with git log, due to file argument path format.

**Which issue(s) this PR fixes**:
Fixes gardener/documentation#116