### PR TITLE
update job-image to 1.816.0 image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN curl -fsSLO --compressed https://github.com/gohugoio/hugo/releases/download/
     && curl -fsSL --compressed https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt | grep " ${HUGO_ID}_Linux-64bit.tar.gz\$" | sha256sum -c - \
     && tar -xzf ${HUGO_ID}_Linux-64bit.tar.gz \
     && mkdir -p /usr/local/bin \
-    && mv ./hugo /usr/local/bin/hugo 
+    && mv ./hugo /usr/local/bin/hugo
 
-FROM eu.gcr.io/gardener-project/cc/job-image:1.778.0
+FROM eu.gcr.io/gardener-project/cc/job-image:1.816.0
 
 COPY --from=base /usr/local/bin/hugo /usr/local/bin/hugo
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets eu.gcr.io/gardener-project/cc/job-image:1.816.0 Docker image as base to website-generator Dockerfile

It sets the cc/job-image to newer version 1.816.0

**Which issue(s) this PR fixes**:
Fixes #
website-generator image had an issue, where it couldn't reach github.com from the container
 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
website-generator Docker image uses eu.gcr.io/gardener-project/cc/job-image:1.816.0 as base
```
