### PR TITLE
Change image registry, upgrade docforge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  alpine:3.11 as base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 as base
 
 RUN apk add curl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- change alpine base image registry to gcr to prevent hitting pulls quota
- upgrade docforge to apply latest fixes