### PR TITLE
Add local build ENV var

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -7,6 +7,7 @@ else
   READLINK_BIN="readlink"
 fi
 
+LOCAL_BUILD=${LOCAL_BUILD:-false}
 HUGO=${HUGO:-hugo}
 FORK=${FORK:-gardener}
 BRANCH=${BRANCH:-master}
@@ -93,6 +94,10 @@ cd hugo
 # Generate site from ${content} into ${website}
 #
 echo
+
+if [[ ${LOCAL_BUILD} = "false" ]]; then
+  npm install postcss-cli
+fi
 
 hugo --minify --destination ${website}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add local build ENV var. In this way there will be separation between CI/CD Build and Local build

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
LOCAL_BUILD env var is added. If it is set to true, then there will not be installed npm packages
```
