### PR TITLE
Remove description from the docs pages layout

### DIFF
--- a/hugo/layouts/docs/list.html
+++ b/hugo/layouts/docs/list.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 <div class="td-content">
-    {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
             {{ partial "reading-time.html" . }}
         {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove description from the docs pages layout because usually it duplicates the first Header

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
