### PR TITLE
Add make-image-stable step in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,9 @@ image-build:
 .PHONY: image-push
 image-push:
 	@scripts/image-push
+# `make image-stable` pushes a local image to the project GCR repository with tag :stable. An installed and authenticated gcloud tool
+# is required to perform the operation. The image to push is identified by its tag. Use semver for tags.
+# Example: `$ make image-stable TAG=10.0.0`
+.PHONY: image-stable
+image-stable:
+	@scripts/image-stable

--- a/scripts/image-stable
+++ b/scripts/image-stable
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -ex
+
+HOST=eu.gcr.io
+PROJECT=gardener-project
+IMAGE=gardener-website-generator
+for i in "$@"
+do
+case $i in
+  --t=*|--tag=*) 
+    TAG="${i#*=}"
+    shift
+    ;;
+  *) echo "Unknown parameter passed: $i"; exit 1;;
+esac
+done
+if [[ -z "${TAG}" ]]; then
+  echo "No image tag specified. Either use the --tag=your-tag option (-t=your-tag), or $TAG environment variable to specify it. The -t | --tag option has priority."
+  exit 1;
+fi
+
+IMAGE="${HOST}/${PROJECT}/${IMAGE}"
+foundImage=$(docker images ${IMAGE}:${TAG} | tail -n +2)
+if [[ -z "${foundImage}" ]]; then
+  echo "Pulling locally image ${IMAGE}:${TAG}"
+  docker pull ${IMAGE}:${TAG}
+fi
+
+echo "Tagging image with tag ${TAG} as stable"
+docker tag ${IMAGE}:${TAG} ${IMAGE}:stable
+
+echo "Pushing image to GCR. Tagged as :stable"
+docker push ${IMAGE}:stable


### PR DESCRIPTION
**What this PR does / why we need it**:
Make image-stable step is added in the Makefile

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
make image-stable step is added in the Makefile
```
