### PR TITLE
Switch to stable version for releases instead of hardcoded ones

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -25,7 +25,7 @@ gardener-website-generator:
     head-update:
       steps:
         build:
-          image: 'eu.gcr.io/gardener-project/gardener-website-generator:10.19.0'
+          image: 'eu.gcr.io/gardener-project/gardener-website-generator:stable'
           publish_to: ['gardener_website', 'gardener_documentation']
           vars:
               RELEASES_COUNT: '1'


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch to stable version for releases instead of hardcoded ones

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@dimitar-kostadinov @Kostov6 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The releases now will use stable versions instead of hardcoded ones
```
