### PR TITLE
Update gardener-website-generator image to 10.27.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -25,7 +25,7 @@ gardener-website-generator:
     head-update:
       steps:
         build:
-          image: 'eu.gcr.io/gardener-project/gardener-website-generator:10.26.0'
+          image: 'eu.gcr.io/gardener-project/gardener-website-generator:10.27.0'
           publish_to: ['gardener_website', 'gardener_documentation']
           vars:
               RELEASES_COUNT: '1'


### PR DESCRIPTION
**What this PR does / why we need it**:
Update gardener-website-generator image to 10.27.0
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
