### PR TITLE
Use docforge:v0.29.0 & gardener-website-generator:10.32.0 images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -25,7 +25,7 @@ gardener-website-generator:
     head-update:
       steps:
         build:
-          image: 'eu.gcr.io/gardener-project/gardener-website-generator:10.31.0'
+          image: 'eu.gcr.io/gardener-project/gardener-website-generator:10.32.0'
           publish_to: ['gardener_website', 'gardener_documentation']
           vars:
               RELEASES_COUNT: '1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 as base
 
 RUN apk add curl
 
-ENV HUGO_VERSION=0.83.1
+ENV HUGO_VERSION=0.95.0
 ENV HUGO_TYPE=_extended
 ENV HUGO_ID=hugo${HUGO_TYPE}_${HUGO_VERSION}
 
@@ -12,7 +12,7 @@ RUN curl -fsSLO --compressed https://github.com/gohugoio/hugo/releases/download/
     && mkdir -p /usr/local/bin \
     && mv ./hugo /usr/local/bin/hugo
 
-FROM eu.gcr.io/gardener-project/docforge:v0.28.0 as docforge
+FROM eu.gcr.io/gardener-project/docforge:v0.29.0 as docforge
 FROM registry-1.docker.io/gardenerci/cc-job-image:1.1299.0
 
 COPY --from=docforge /usr/local/bin/docforge /usr/local/bin/docforge


### PR DESCRIPTION
**What this PR does / why we need it**:
Use docforge:v0.29.0 & gardener-website-generator:10.32.0 images
Updates HUGO to v.0.95.0
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
Updates HUGO to v.0.95.0
```
