### PR TITLE
Removing docker build issue workaround

### DIFF
--- a/scripts/image-build
+++ b/scripts/image-build
@@ -39,10 +39,3 @@ ctxpath="$(${READLINK_BIN} -f "$(dirname "${0}")/..")"
 
 echo "Building $HOST/$PROJECT/$IMAGE tagged as :$TAG and :latest"
 docker build --no-cache=true -t "$HOST/$PROJECT/$IMAGE:$TAG" -t "$HOST/$PROJECT/$IMAGE:latest" "$ctxpath" | tee /tmp/docker_build_result.log
-
-# Due to a bug in Docker we need to analyse the log to find out if build passed (see https://github.com/dotcloud/docker/issues/1875)
-RESULT=$(tail -n 1 /tmp/docker_build_result.log)
-if [[ "$RESULT" != *Successfully* ]];
-then
-  exit 1
-fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing workaround in image_build.sh for issue https://github.com/dotcloud/docker/issues/1875

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Removing workaround in image_build.sh for docker build issue
```
