### PR TITLE
Updated "404 Page Not Found" page layout

### DIFF
--- a/.ci/404.sh
+++ b/.ci/404.sh
@@ -32,12 +32,14 @@ const newLinks = links.map((element, index) => [element, titles[index]]
     let a = document.createElement('a')
     a.textContent = el[1]
     a.setAttribute("href",el[0])
+    li.setAttribute("style","margin-bottom: 10px;")
     li.appendChild(a)
     ul.appendChild(li);
 })
 
 if (newLinks.length > 0) {
-    document.getElementById('404-descr').innerHTML = "It seems to be moved. Please check the possible locations of your page:"
+    document.getElementById('404-descr').innerHTML = "It seems to have been planted somewhere else. Try checking some of these spots:"
+    document.getElementById('404-redirect').innerHTML = "You could also go back to our <a href="{{ "/" | relURL }}">home page</a> or use the search bar to find what you were looking for."
 }
 
 EOF

--- a/hugo/layouts/404.html
+++ b/hugo/layouts/404.html
@@ -1,12 +1,16 @@
 {{ define "main"}}
-    <main id="main" style="display: flex; justify-content: center; align-items: center;">
-      <div style="text-align: center; display: block;">
-        <h3 style="margin-bottom: 20px;">Page Not Found</h3>
-        <p id="404-descr">Looks like you've followed a broken link or entered a URL that doesn't exist.</p>
-        <ul id="links" style="padding-left: 0px; list-style-position: inside;"></ul>
-        <p>You could use the search bar or go back to our <a href="{{ "/" | relURL }}">home page</a>.</p>
+    <div id="main" style="margin-top: 2%; display: flex; justify-content: center; align-items: center;">
+      <!-- <div><img src="../../images/404-image-resized.svg" style="max-width: 100%; height: auto; width: auto\9;">
+        <p style="font-size:10px">Image by <a href="https://www.freepik.com/free-vector/404-error-with-landscape-concept-illustration_20602785.htm#query=404%20illustrations&amp;position=0&amp;from_view=keyword&amp;track=ais_user&amp;uuid=bf908625-fffb-449b-bf9f-701f0c081188">storyset</a> on Freepik</p>
+      </div> -->
+      <div style="text-align: center; display: flex; flex-direction: column; justify-content: center; align-items: center;">
+        <h4 style="margin-bottom: 20px;">Page Not Found</h3>
+        <p id="404-descr">We dug around, but couldn't find the page that you were looking for.</p>
+        <ul id="links" style="padding: 0; list-style-position:inside; text-align: left; font-size: 140%;"></ul>
+        <p id="404-redirect">You could go back to our <a href="{{ "/" | relURL }}">home page</a> or use the search bar to find what you were looking for.</p>
+        <div style="margin-bottom: 20%;"></div>
        </div>
-    </main>
+      </div>
 
     {{ $assetBusting := not .Site.Params.disableAssetsBusting }}
     <script src='{{ "/js/404.js" | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}'></script>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the layout of the "404 Page Not Found" page:
- reworked the displayed text
- decreased the size of the title
- increased the size of the links
- added spacing between links
- aligned the bullet points to the left in a centered div
- added code to place an image (currently as a comment; image TBD)
 
**Which issue(s) this PR fixes**:
Fixes #212 

**Special notes for your reviewer**:
![Screenshot 2024-07-04 at 10 41 53](https://github.com/gardener/website-generator/assets/25197046/03a990cb-5dc1-4545-ae86-7589b8837087)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
