### PR TITLE
Fixed links in Page Not Found page

### DIFF
--- a/.ci/404.sh
+++ b/.ci/404.sh
@@ -39,7 +39,7 @@ const newLinks = links.map((element, index) => [element, titles[index]]
 
 if (newLinks.length > 0) {
     document.getElementById('404-descr').innerHTML = "It seems to have been planted somewhere else. Try checking some of these spots:"
-    document.getElementById('404-redirect').innerHTML = "You could also go back to our <a href="{{ "/" | relURL }}">home page</a> or use the search bar to find what you were looking for."
+    document.getElementById('404-redirect').innerHTML = 'You could also go back to our <a href="https://gardener.cloud/">home page</a> or use the search bar to find what you were looking for.'
 }
 
 EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes links not being shown in the "Page Not Found" error page.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
