### PR TITLE
Fix redirection on first click of Documentation

### DIFF
--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -336,5 +336,17 @@
   {{ partialCached "scripts.html" . }}
 
 </body>
-
+<script>
+  document.querySelectorAll(".taxonomy-term").forEach((el) => {
+    el.addEventListener("click",(event) => {
+      const roleSelected = event.currentTarget.innerHTML
+      window.sessionStorage.setItem("role_selected",roleSelected)
+      location.reload()
+    })
+  })
+  const taxonomyTerms = Array.from(document.querySelectorAll(".taxonomy-term"))
+  taxonomyTerms
+    .filter(tt => tt.innerHTML.includes(window.sessionStorage.getItem("role_selected")))
+    .map(tt => tt.setAttribute("class","taxonomy-term selectedTaxonomy"))
+</script>
 </html>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the page redirection on first click of Documentation dropdown menu

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
On first click on the Documentation dropdown menu, it will now redirect you to the correct persona filtered page.
```
