### PR TITLE
Add support for Github notes syntax

### DIFF
--- a/hugo/layouts/_default/_markup/render-blockquote-alert.html
+++ b/hugo/layouts/_default/_markup/render-blockquote-alert.html
@@ -1,0 +1,26 @@
+
+{{ $emojis := dict
+  "caution" ":rotating_light:"
+  "important" ":exclamation:"
+  "note" ":information_source:"
+  "tip" ":bulb:"
+  "warning" ":warning:"
+}}
+
+{{ if eq .Type "alert" }}
+  <blockquote class="alert alert-{{ .AlertType }}">
+    <p class="alert-heading">
+      {{ transform.Emojify (index $emojis .AlertType) }}
+      {{ with .AlertTitle }}
+        {{ . }}
+      {{ else }}
+        {{ or (i18n .AlertType) (title .AlertType) }}
+      {{ end }}
+    </p>
+    {{ .Text }}
+  </blockquote>
+{{ else }}
+  <blockquote>
+    {{ .Text }}
+  </blockquote>
+{{ end }}

--- a/hugo/layouts/_default/_markup/render-blockquote-regular.html
+++ b/hugo/layouts/_default/_markup/render-blockquote-regular.html
@@ -1,0 +1,3 @@
+<blockquote>
+  {{ .Text }}
+</blockquote>

--- a/hugo/layouts/partials/navbar.html
+++ b/hugo/layouts/partials/navbar.html
@@ -23,6 +23,9 @@
 	.td-search__input {
 		max-width: 90%;
 	}
+	.td-search:not(:focus-within) {
+		color: #fff !important
+	}
 	</style>
 	<a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ (


### PR DESCRIPTION
**What this PR does / why we need it**:
Beautify the look of notes parsed from .md files

**Which issue(s) this PR fixes**:
Fixes #222 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The website now supports the `[!(NOTE|IMPORTANT|TIP|WARNING|CAUTION)]` syntax
```
