### PR TITLE
[Docker] Running docforge using docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+docforge_config.yaml
 hugo/content
 hugo/public
 hugo/resources

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ EXPOSE 1313
 
 WORKDIR /hugo
 
-CMD hugo serve $HUGO_FLAGS
+ENV DOCFORGE_CONFIG=/run/secrets/docforge_config
+CMD rm -rf content && docforge && hugo serve $HUGO_FLAGS

--- a/README.md
+++ b/README.md
@@ -43,19 +43,27 @@ Before you can setup your local version of the website, you need to have:
 
 4. Run `npm install` in `hugo` and `hugo/themes/docsy` 
 
-### Build Website Content
+### Run using the terminal
 
-Run `make build-local`
+1. Run `make build-local`
 
-### Run web server using the terminal
+2. Run `cd hugo && hugo serve`
 
-Run `cd hugo && hugo serve`
-
-#### Run web server using `docker compose up`
+### Run using `docker compose up`
 
 1. Initially build a local image `docker build -t testing-website-image .`
 
-2. Run `docker compose up`
+2. Provide `docforge_config.yaml`
+``` yaml
+manifest: https://github.com/gardener/documentation/blob/master/.docforge/website.yaml
+destination: content
+hugo: true
+github-oauth-token-map:
+  "github.com": <token>
+skip-link-validation: true
+```
+
+3. Run `docker compose up`
 
 ### Test Local Changes
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,3 +7,8 @@ services:
     - 1313:1313
     volumes:
     - ./hugo:/hugo 
+    secrets:
+    - docforge_config
+secrets:
+  docforge_config:
+    file: ./docforge_config.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
`docker compose up` requires `dockforge_config.yaml` that is used by docforge to load the content

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/website-generator/issues/238

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
