### PR TITLE
[Docker] Move `DOCFORGE_CONFIG` in compose instead of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,4 @@ EXPOSE 1313
 
 WORKDIR /hugo
 
-ENV DOCFORGE_CONFIG=/run/secrets/docforge_config
 CMD rm -rf content && docforge && hugo serve $HUGO_FLAGS

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,7 @@ services:
     image: testing-website-image
     environment:
       HUGO_FLAGS: "--bind=0.0.0.0"
+      DOCFORGE_CONFIG: /run/secrets/docforge_config
     ports:
     - 1313:1313
     volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the setting of the environment variable `DOCFORGE_CONFIG` to be done from the `compose.yaml` file to allow supporting the ci/cd scenario

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
