### PR TITLE
[Docker] support local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,22 @@ In order to test local changes, for example [gardener/documentation](https://git
    ```
 4. Run `make build`
 5. Run `cd hugo && hugo serve`
+
+### Local dev using `docker compose up`
+
+If you want to run the web server reflecting local changes done to some locally cloned repositories you need to go trough the following steps:
+
+1. Adapt `compose.yaml` by adding a volume mount entry for each repository
+   ```yaml
+    volumes:
+    - <path_to_cloned_repo_1>:/resourceMappings/<repo_1>
+    - <path_to_cloned_repo_2>:/resourceMappings/<repo_2>
+    - ...
+   ```
+2. Adapt `docforge_config.yaml`
+   ```yaml
+   resourceMappings:
+     <repo_1_url>: /resourceMappings/<repo_1>
+     <repo_2_url>: /resourceMappings/<repo_2>
+     ...
+   ```

--- a/README.md
+++ b/README.md
@@ -98,3 +98,10 @@ If you want to run the web server reflecting local changes done to some locally 
      <repo_2_url>: /resourceMappings/<repo_2>
      ...
    ```
+
+If you want to make ad-hock changes to the website add the following volume mount entry. Chaning files in `<path_to_locally_placed_hugo>` will trigger website rebuild:
+
+```yaml
+volumes:
+- <path_to_locally_placed_hugo>:/hugo 
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the steps explaining how to develop locally

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/website-generator/issues/238

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
