### PR TITLE
[Docker] Add `BUILD_DESTINATION`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 1313
 
 WORKDIR /hugo
 
-CMD rm -rf content && docforge && hugo serve $HUGO_FLAGS
+CMD rm -rf content && docforge && if [ -n "$BUILD_DESTINATION" ]; then hugo --minify --destination "$BUILD_DESTINATION"; else hugo serve $HUGO_FLAGS; fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to build the website and put it's content into the folder `BUILD_DESTINATION` if that environment variable is set

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
