### PR TITLE
[Docker] Add `DOCFORGE_CONFIG_PATH`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN mkdir -p hugo/themes && cd hugo/themes && git clone https://github.com/googl
 
 WORKDIR /hugo
 
-CMD rm -rf content && docforge && if [ -n "$BUILD_DESTINATION" ]; then hugo --minify --destination "$BUILD_DESTINATION"; else hugo serve $HUGO_FLAGS; fi
+CMD rm -rf content && if [ -n "$DOCFORGE_CONFIG_PATH" ]; then export DOCFORGE_CONFIG="/${DOCFORGE_CONFIG_PATH}/config"; fi ; docforge && if [ -n "$BUILD_DESTINATION" ]; then hugo --minify --destination "$BUILD_DESTINATION"; else hugo serve $HUGO_FLAGS; fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `DOCFORGE_CONFIG_PATH` environment variable to `Dockerfile` that lets docforge use `DOCFORGE_CONFIG_PATH/config` as configuration. If path is relative it will be resolved relative to the container's root

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
