### PR TITLE
Diasbe unnessesary `enableGitInfo`

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -6,7 +6,7 @@ languageCode = "en-US"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir= false
 contentDir="content"
-enableGitInfo = true
+enableGitInfo = false
 enableEmoji = true
 disableKinds = ["taxonomy"]
 


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
