### PR TITLE
Revert removal of docs/list.html layout

### DIFF
--- a/hugo/layouts/docs/list.html
+++ b/hugo/layouts/docs/list.html
@@ -1,0 +1,14 @@
+{{ define "main" }}
+<div class="td-content">
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+            {{ partial "reading-time.html" . }}
+        {{ end }}
+	{{ .Content }}
+        {{ partial "docs/section-index.html" . }}
+	{{ if (.Site.Config.Services.Disqus.Shortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	{{ partial "page-meta-lastmod.html" . }}
+</div>
+{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts the removal of grouping of articles in docs index page.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
