### PR TITLE
Clean up sidebars hiding main content on mobile devices

### DIFF
--- a/hugo/static/js/resizable-sidebar.js
+++ b/hugo/static/js/resizable-sidebar.js
@@ -1,3 +1,15 @@
+function isMobileDevice() {
+  return /Mobi|Android/i.test(navigator.userAgent);
+}
+
+$(document).ready(() => {
+  // Check if the device is mobile
+  if (isMobileDevice()) {
+      const targetElement = document.querySelector("aside");
+      if (targetElement) {
+          $(targetElement).css("display", "none");
+      }
+  } else {
 const selectTarget = (fromElement, selector) => {
     if (!(fromElement instanceof HTMLElement)) {
       return null;
@@ -95,3 +107,4 @@ $(document).ready( () => {
     }
     $(document.body).css("display","block")
 })  
+}});


### PR DESCRIPTION
**What this PR does / why we need it**:
A dirty fix for the mobile version of the website where the sidebars are already unusable and don't show anything, but they limit the main content's size. Introduces a check for mobile devices.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
A temporary fix for current ongoing events and better promoting using the website.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
