### PR TITLE
Removed VMware vSphere as infrastructure

### DIFF
--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -313,10 +313,10 @@
               <img style="margin-left: 20px;" src='{{"images/lp/platforms/sap.svg" | relURL }}' class="platform-icon">
               <div class="platform-text">SAP </br> Data Center</div>
             </li>
-            <li>
+            <!-- <li>
               <img src='{{"images/lp/platforms/vmware.svg" | relURL }}' class="platform-icon">
               <div class="platform-text">VMware vSphere</div>
-            </li>
+            </li> -->
             <li>
               <img src='{{"images/lp/platforms/iron_core.svg" | relURL }}' class="platform-icon">
               <div class="platform-text">Iron Core</div>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes VMware vSphere as infrastructure, as it is not supported by Gardener.

![image](https://github.com/user-attachments/assets/899ff7cb-fe3b-49af-a383-3b75cf7b5193)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
