### PR TITLE
parse url role parameter and set to session

### DIFF
--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -337,6 +337,16 @@
 
 </body>
 <script>
+  const params = new URLSearchParams(window.location.search);
+  const roleParam = params.get("role");
+  if (roleParam) {
+    const allowedRoles = Array.from(document.querySelectorAll(".taxonomy-term"))
+      .map(el => el.innerHTML);
+    if (allowedRoles.includes(roleParam) && window.sessionStorage.getItem("role_selected") !== roleParam) {
+      window.sessionStorage.setItem("role_selected", roleParam);
+    }
+  }
+
   document.querySelectorAll(".taxonomy-term").forEach((el) => {
     el.addEventListener("click",(event) => {
       const roleSelected = event.currentTarget.innerHTML

--- a/hugo/static/js/persona-filtering.js
+++ b/hugo/static/js/persona-filtering.js
@@ -1,3 +1,13 @@
+const params = new URLSearchParams(window.location.search);
+const roleParam = params.get("role");
+if (roleParam) {
+  const allowedRoles = Array.from(document.querySelectorAll(".taxonomy-term"))
+    .map(el => el.innerHTML);
+  if (allowedRoles.includes(roleParam) && window.sessionStorage.getItem("role_selected") !== roleParam) {
+    window.sessionStorage.setItem("role_selected", roleParam);
+  }
+}
+
 document.querySelectorAll(".taxonomy-term").forEach((el) => {
     el.addEventListener("click",(event) => {
       const roleSelected = event.currentTarget.innerHTML


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new feature that allows the documentation persona to be set via a URL GET parameter. For example:

- https://gardener.cloud/docs/?role=Users
- https://gardener.cloud/docs/?role=Operators

This enhancement makes it easy to preselect the appropriate documentation context based on the user's role.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:

```improvement operator
NONE
```
