### PR TITLE
Switch Slack references to Gardener workspace

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -23,7 +23,7 @@
     <img src='{{"images/lp/gardener-logo.svg" | relURL}}' alt="Logo Gardener" class="logo" />
     <ul class="media-wr">
       <li>
-        <a target="_blank" href="https://kubernetes.slack.com/archives/CB57N0BFG">
+        <a target="_blank" href="https://gardener-cloud.slack.com/">
           <img src='{{"images/branding/slack-logo-white.svg" | relURL}}' class="media-icon" />
           <div class="media-text">Slack</div>
         </a>


### PR DESCRIPTION
/kind enhancement
/area open-source

**What this PR does / why we need it**:

This PR switches all Slack references to the dedicated Gardener Project workspace.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/documentation/issues/606

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
